### PR TITLE
Add pulse simulation grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Pulse-Core
+
+This project contains a simple pulse simulation playground. Open `public/index.html` in a browser to try it out. Click cells to toggle them on or off, then press **Start** to watch the grid evolve using a flicker rule.
+
+This scaffolding separates UI from simulation logic to allow future growth. Upcoming work will add pulse direction, folding geometry and substrate density.

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,112 @@
+// Basic pulse simulation grid
+// Each cell toggles between 0 and 1.
+// Folding logic will hook into update() using the foldSlider value.
+const canvas = document.getElementById('grid');
+const ctx = canvas.getContext('2d');
+const startBtn = document.getElementById('startBtn');
+const stopBtn = document.getElementById('stopBtn');
+const speedSlider = document.getElementById('speedSlider');
+const foldSlider = document.getElementById('foldSlider');
+
+let rows = 50;
+let cols = 50;
+let cellSize;
+let grid = [];
+let running = false;
+let intervalId = null;
+
+function resizeCanvas() {
+    canvas.width = canvas.clientWidth;
+    canvas.height = canvas.clientHeight;
+    cellSize = Math.min(canvas.width / cols, canvas.height / rows);
+    drawGrid();
+}
+
+function createGrid() {
+    grid = [];
+    for (let r = 0; r < rows; r++) {
+        const row = [];
+        for (let c = 0; c < cols; c++) {
+            row.push(0);
+        }
+        grid.push(row);
+    }
+}
+
+function drawGrid() {
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+            ctx.fillStyle = grid[r][c] === 1 ? 'green' : '#222';
+            ctx.fillRect(c * cellSize, r * cellSize, cellSize - 1, cellSize - 1);
+        }
+    }
+}
+
+function getNeighborsSum(r, c) {
+    let sum = grid[r][c];
+    for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+            if (dr === 0 && dc === 0) continue;
+            const nr = (r + dr + rows) % rows;
+            const nc = (c + dc + cols) % cols;
+            sum += grid[nr][nc];
+        }
+    }
+    return sum;
+}
+// Update all cells based on the flicker rule f(n) = (n + 1)^2 % 2
+// Future folding mechanics can modify the grid here using foldSlider.value
+
+function update() {
+    const next = [];
+    for (let r = 0; r < rows; r++) {
+        const row = [];
+        for (let c = 0; c < cols; c++) {
+            const n = getNeighborsSum(r, c);
+            row.push(((n + 1) ** 2) % 2);
+        }
+        next.push(row);
+    }
+    grid = next;
+    drawGrid();
+}
+// UI handlers
+
+
+function toggleCell(event) {
+    if (running) return;
+    const rect = canvas.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    const c = Math.floor(x / cellSize);
+    const r = Math.floor(y / cellSize);
+    grid[r][c] = grid[r][c] === 1 ? 0 : 1;
+    drawGrid();
+}
+
+function start() {
+    if (running) return;
+    running = true;
+    startBtn.disabled = true;
+    stopBtn.disabled = false;
+    const speed = parseInt(speedSlider.value);
+    intervalId = setInterval(update, speed);
+}
+
+function stop() {
+    running = false;
+    startBtn.disabled = false;
+    stopBtn.disabled = true;
+    clearInterval(intervalId);
+}
+
+window.addEventListener('resize', resizeCanvas);
+canvas.addEventListener('click', toggleCell);
+startBtn.addEventListener('click', start);
+stopBtn.addEventListener('click', stop);
+
+createGrid();
+resizeCanvas();
+// Additional hooks for pulse direction and substrate density will be added later.

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pulsecore</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="controls">
+        <button id="startBtn">Start</button>
+        <button id="stopBtn" disabled>Stop</button>
+        <label>Tick Speed: <input type="range" id="speedSlider" min="50" max="1000" step="50" value="500"></label>
+        <label>Fold Threshold: <input type="range" id="foldSlider" min="0" max="10" step="1" value="0"></label>
+    </div>
+    <canvas id="grid"></canvas>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,21 @@
+body {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    background-color: #111;
+    color: #eee;
+    font-family: Arial, sans-serif;
+}
+
+#controls {
+    padding: 10px;
+    background: #222;
+}
+
+#grid {
+    flex: 1;
+    width: 100%;
+    background: #000;
+    display: block;
+}


### PR DESCRIPTION
## Summary
- add basic front-end scaffolding for Pulsecore
- implement canvas grid with start/stop controls
- apply flicker rule `(n + 1)^2 % 2` every tick
- document how to run the interactive demo

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b4741a90c8330b81662d5dbe6ee86