### PR TITLE
Add full-screen grid with zoom controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Pulse-Core
 
-This project contains a simple pulse simulation playground. Open `public/index.html` in a browser to try it out. Click cells to toggle them on or off, then press **Start** to watch the grid evolve using a flicker rule.
+This project contains a simple pulse simulation playground. Open `index.html` in a browser to try it out. Click cells to toggle them on or off, then press **Start** to watch the grid evolve using a flicker rule.
 
 This scaffolding separates UI from simulation logic to allow future growth. Upcoming work will add pulse direction, folding geometry and substrate density.

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pulsecore</title>
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="public/style.css">
 </head>
 <body>
     <div id="controls">
@@ -17,6 +17,6 @@
     </div>
     <canvas id="grid"></canvas>
 
-    <script src="app.js"></script>
+    <script src="public/app.js"></script>
 </body>
 </html>

--- a/public/app.js
+++ b/public/app.js
@@ -7,19 +7,21 @@ const startBtn = document.getElementById('startBtn');
 const stopBtn = document.getElementById('stopBtn');
 const speedSlider = document.getElementById('speedSlider');
 const foldSlider = document.getElementById('foldSlider');
+const zoomSlider = document.getElementById('zoomSlider');
 
-let rows = 50;
-let cols = 50;
-let cellSize;
+let cellSize = parseInt(zoomSlider.value);
+let rows;
+let cols;
 let grid = [];
 let running = false;
 let intervalId = null;
 
-function resizeCanvas() {
-    canvas.width = canvas.clientWidth;
-    canvas.height = canvas.clientHeight;
-    cellSize = Math.min(canvas.width / cols, canvas.height / rows);
-    drawGrid();
+function updateDimensions() {
+    cellSize = parseInt(zoomSlider.value);
+    cols = Math.floor(window.innerWidth / cellSize);
+    rows = Math.floor(window.innerHeight / cellSize);
+    canvas.width = cols * cellSize;
+    canvas.height = rows * cellSize;
 }
 
 function createGrid() {
@@ -74,7 +76,6 @@ function update() {
 }
 // UI handlers
 
-
 function toggleCell(event) {
     if (running) return;
     const rect = canvas.getBoundingClientRect();
@@ -82,8 +83,10 @@ function toggleCell(event) {
     const y = event.clientY - rect.top;
     const c = Math.floor(x / cellSize);
     const r = Math.floor(y / cellSize);
-    grid[r][c] = grid[r][c] === 1 ? 0 : 1;
-    drawGrid();
+    if (r >= 0 && r < rows && c >= 0 && c < cols) {
+        grid[r][c] = grid[r][c] === 1 ? 0 : 1;
+        drawGrid();
+    }
 }
 
 function start() {
@@ -102,11 +105,27 @@ function stop() {
     clearInterval(intervalId);
 }
 
-window.addEventListener('resize', resizeCanvas);
+function init() {
+    updateDimensions();
+    createGrid();
+    drawGrid();
+}
+
+window.addEventListener('resize', () => {
+    updateDimensions();
+    createGrid();
+    drawGrid();
+});
+
+zoomSlider.addEventListener('input', () => {
+    updateDimensions();
+    createGrid();
+    drawGrid();
+});
+
 canvas.addEventListener('click', toggleCell);
 startBtn.addEventListener('click', start);
 stopBtn.addEventListener('click', stop);
 
-createGrid();
-resizeCanvas();
+init();
 // Additional hooks for pulse direction and substrate density will be added later.

--- a/public/style.css
+++ b/public/style.css
@@ -1,21 +1,26 @@
 body {
     margin: 0;
-    display: flex;
-    flex-direction: column;
     height: 100vh;
+    overflow: hidden;
     background-color: #111;
     color: #eee;
     font-family: Arial, sans-serif;
+    position: relative;
 }
 
 #controls {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    background: rgba(34, 34, 34, 0.8);
     padding: 10px;
-    background: #222;
+    z-index: 10;
+    border-radius: 4px;
 }
 
 #grid {
-    flex: 1;
-    width: 100%;
+    width: 100vw;
+    height: 100vh;
     background: #000;
     display: block;
 }


### PR DESCRIPTION
## Summary
- make the playground available via `index.html` at the repo root
- allow zooming all the way down to 1px cells
- position controls as an overlay so the grid fills the screen

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686b4a2f3b148330ab256cde99f90b9d