### PR TITLE
Adjust cell picking with canvas scale

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -79,8 +79,10 @@ function update() {
 function toggleCell(event) {
     if (running) return;
     const rect = canvas.getBoundingClientRect();
-    const x = event.clientX - rect.left;
-    const y = event.clientY - rect.top;
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    const x = (event.clientX - rect.left) * scaleX;
+    const y = (event.clientY - rect.top) * scaleY;
     const c = Math.floor(x / cellSize);
     const r = Math.floor(y / cellSize);
     if (r >= 0 && r < rows && c >= 0 && c < cols) {


### PR DESCRIPTION
## Summary
- handle canvas scale when converting click position to grid coordinates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686b4ff3167c833082c4eb34ea8d37c0