### PR TITLE
Fix color inversion on pulse cells

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -77,8 +77,8 @@ function drawGrid() {
     for (let r = 0; r < rows; r++) {
         for (let c = 0; c < cols; c++) {
             let color = '#000';
-            if (touchedGrid[r][c] && grid[r][c] === 1) {
-                color = (pulseCounter % 2 === 0)
+            if (touchedGrid[r][c]) {
+                color = grid[r][c] === 1
                     ? colorGrid[r][c]
                     : invertColor(colorGrid[r][c]);
             }


### PR DESCRIPTION
## Summary
- clean up drawGrid logic so cells toggle between the selected color and its inverse

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686b5fd7c84c8330a06f3b52117712c2