### PR TITLE
Fix pulse injector activation

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -157,6 +157,7 @@ function applyTool(r, c) {
     } else if (tool === 'pulse') {
         const len = parseInt(pulseLengthInput.value) || 1;
         pulses.push({ r, c, remaining: len * 2, color: currentColor });
+        grid[r][c] = 1;
         colorGrid[r][c] = currentColor;
         touchedGrid[r][c] = true;
     } else if (tool === 'stamper') {


### PR DESCRIPTION
## Summary
- make the pulse tool activate the clicked cell so it starts on
  immediately

## Testing
- `node --check public/app.js`

------
https://chatgpt.com/codex/tasks/task_e_686b65d2b2348330b24d3833f67bffdd