### PR TITLE
Enable editing during pulses

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ This project contains a simple pulse simulation playground. Open `index.html` in
 
 ## Usage
 
-1. Click cells on the grid to activate them.
-2. Press **Start** to run the simulation or **Stop** to pause.
+1. Click cells on the grid to activate them. Brushed cells will blink once the
+   simulation starts.
+2. Press **Start** to run the simulation or **Stop** to pause. You can continue
+   editing the grid while the simulation is running.
 3. Adjust **Pulse Speed** and **Zoom** with the sliders.
 4. Choose a tool from the **Tool** drop-down:
    - **Brush** – paint live cells.
@@ -13,7 +15,10 @@ This project contains a simple pulse simulation playground. Open `index.html` in
    - **Pulse Injector** – inject a repeating 0→1→0 signal for the selected **Injector Length** and color.
    - **Pattern Stamper** – stamp a saved pattern at the clicked location. Use **Save Pattern** to store the current live cells.
 
-Use the **Reverse** button to step backward through previous pulses. A color picker lets you choose the color for brush strokes, injected pulses and stamped patterns.
+Use the **Reverse** button to step backward through previous pulses. A color
+picker lets you choose the color for brush strokes, injected pulses and stamped
+patterns. The **Pulse Injector** tool creates explicit pulses, while brushed
+cells simply toggle on each tick.
 
 This scaffolding separates UI from simulation logic to allow future growth. Upcoming work will add pulse direction, folding geometry and substrate density.
 

--- a/public/app.js
+++ b/public/app.js
@@ -130,12 +130,14 @@ function update() {
         // Clone the current grid so we can apply pulses without altering
         // the original during iteration.
         const next = grid.map(row => row.slice());
+        const pulsed = new Set();
         // In the old implementation every cell was recalculated here,
         // forcing a full-frame flicker. Now we only modify cells affected
         // by active pulses or future mechanics.
         pulses.forEach(p => {
             if (p.r >= 0 && p.r < rows && p.c >= 0 && p.c < cols) {
                 next[p.r][p.c] = p.remaining % 2;
+                pulsed.add(p.r + ',' + p.c);
                 if (!touchedGrid[p.r][p.c]) {
                     colorGrid[p.r][p.c] = p.color;
                     touchedGrid[p.r][p.c] = true;
@@ -143,6 +145,13 @@ function update() {
                 p.remaining--;
             }
         });
+        for (let r = 0; r < rows; r++) {
+            for (let c = 0; c < cols; c++) {
+                if (touchedGrid[r][c] && !pulsed.has(r + ',' + c)) {
+                    next[r][c] = 1 - next[r][c];
+                }
+            }
+        }
         pulses = pulses.filter(p => p.remaining > 0);
         grid = next;
         pulseCounter++;
@@ -183,7 +192,6 @@ function applyTool(r, c) {
 // UI handlers
 
 function toggleCell(event) {
-    if (running) return;
     const rect = canvas.getBoundingClientRect();
     const scaleX = canvas.width / rect.width;
     const scaleY = canvas.height / rect.height;


### PR DESCRIPTION
## Summary
- allow selecting cells while the simulation is running
- toggle brush cells each tick so they animate
- document blinking brush behaviour and live editing in README

## Testing
- `node -v`
- `npm -v`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686b6fdc993c83308be3016993bfd231