### PR TITLE
Fix pulse persistence and speed control

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
         <button id="startBtn">Start</button>
         <button id="stopBtn" disabled>Stop</button>
         <label>Pulse Speed: <input type="range" id="speedSlider" min="50" max="1000" step="50" value="500"></label>
-        <label>Fold Threshold: <input type="range" id="foldSlider" min="0" max="10" step="1" value="0"></label>
         <label>Zoom: <input type="range" id="zoomSlider" min="1" max="50" step="1" value="10"></label>
         <div id="pulseCounterDisplay">Pulse: <span id="pulseCounter">0</span></div>
         <button id="reverseBtn">Reverse</button>


### PR DESCRIPTION
## Summary
- clean up unused fold slider and neighbors function
- stop perpetual blinking after pulses finish
- allow live updates to simulation speed

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686b76d4c158833093665257979c2953