### PR TITLE
Add color-aware cell evolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This project contains a simple pulse simulation playground. Open `index.html` in
 
 ## Usage
 
-1. Click cells on the grid to activate them. Brushed cells will blink once the
-   simulation starts.
+1. Click cells on the grid to activate them. Each cell stores a color and will
+   evolve based on its neighbors during the simulation.
 2. Press **Start** to run the simulation or **Stop** to pause. You can continue
    editing the grid while the simulation is running.
 3. Adjust **Pulse Speed** and **Zoom** with the sliders.
@@ -17,8 +17,9 @@ This project contains a simple pulse simulation playground. Open `index.html` in
 
 Use the **Reverse** button to step backward through previous pulses. A color
 picker lets you choose the color for brush strokes, injected pulses and stamped
-patterns. The **Pulse Injector** tool creates explicit pulses, while brushed
-cells simply toggle on each tick.
+patterns. Cells now adopt dominant neighbor colors or blend hues when colors
+conflict, enabling emergent multi-color behavior. The **Pulse Injector** tool
+creates explicit pulses while brushed cells remain active.
 
 This scaffolding separates UI from simulation logic to allow future growth. Upcoming work will add pulse direction, folding geometry and substrate density.
 

--- a/public/app.js
+++ b/public/app.js
@@ -22,7 +22,6 @@ let rows;
 let cols;
 let grid = [];
 let colorGrid = [];
-let touchedGrid = [];
 let running = false;
 let intervalId = null;
 
@@ -51,6 +50,57 @@ function invertColor(hex) {
         b.toString(16).padStart(2, '0');
 }
 
+function blendColors(a, colorB) {
+    const ca = parseInt(a.slice(1), 16);
+    const cb = parseInt(colorB.slice(1), 16);
+    const ra = (ca >> 16) & 0xff;
+    const ga = (ca >> 8) & 0xff;
+    const ba = ca & 0xff;
+    const rb = (cb >> 16) & 0xff;
+    const gb = (cb >> 8) & 0xff;
+    const bb = cb & 0xff;
+    const r = Math.floor((ra + rb) / 2);
+    const g = Math.floor((ga + gb) / 2);
+    const bVal = Math.floor((ba + bb) / 2);
+    return '#' + r.toString(16).padStart(2, '0') +
+        g.toString(16).padStart(2, '0') +
+        bVal.toString(16).padStart(2, '0');
+}
+
+function getNeighbors(stateGrid, colorGrid, r, c) {
+    const cells = [];
+    for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+            if (dr === 0 && dc === 0) continue;
+            const nr = (r + dr + rows) % rows;
+            const nc = (c + dc + cols) % cols;
+            cells.push({ state: stateGrid[nr][nc], color: colorGrid[nr][nc] });
+        }
+    }
+    return cells;
+}
+
+function getNextCellState(current, neighbors) {
+    const counts = {};
+    neighbors.forEach(cell => {
+        if (cell.state > 0) {
+            counts[cell.color] = (counts[cell.color] || 0) + 1;
+        }
+    });
+    const dominant = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+    if (dominant.length === 0) {
+        return { state: 0, color: '#000000' };
+    }
+    const [topColor, count] = dominant[0];
+    if (count > 3) {
+        return { state: 1, color: topColor };
+    }
+    if (dominant.length > 1 && dominant[0][1] === dominant[1][1]) {
+        return { state: 1, color: blendColors(dominant[0][0], dominant[1][0]) };
+    }
+    return current.state > 0 ? { state: 1, color: current.color } : { state: 0, color: '#000000' };
+}
+
 function updateDimensions() {
     cellSize = parseInt(zoomSlider.value);
     cols = Math.floor(window.innerWidth / cellSize);
@@ -62,19 +112,15 @@ function updateDimensions() {
 function createGrid() {
     grid = [];
     colorGrid = [];
-    touchedGrid = [];
     for (let r = 0; r < rows; r++) {
         const row = [];
         const cRow = [];
-        const tRow = [];
         for (let c = 0; c < cols; c++) {
             row.push(0);
             cRow.push('#000000');
-            tRow.push(false);
         }
         grid.push(row);
         colorGrid.push(cRow);
-        touchedGrid.push(tRow);
     }
 }
 
@@ -83,12 +129,7 @@ function drawGrid() {
     ctx.fillRect(0, 0, canvas.width, canvas.height);
     for (let r = 0; r < rows; r++) {
         for (let c = 0; c < cols; c++) {
-            let color = '#000';
-            if (touchedGrid[r][c]) {
-                color = grid[r][c] === 1
-                    ? colorGrid[r][c]
-                    : invertColor(colorGrid[r][c]);
-            }
+            const color = grid[r][c] === 1 ? colorGrid[r][c] : '#000000';
             ctx.fillStyle = color;
             ctx.fillRect(c * cellSize, r * cellSize, cellSize - 1, cellSize - 1);
         }
@@ -107,7 +148,6 @@ function update() {
         if (prev) {
             grid = prev.grid;
             colorGrid = prev.colorGrid;
-            touchedGrid = prev.touchedGrid;
             pulses = prev.pulses;
             pulseCounter--;
         }
@@ -115,7 +155,6 @@ function update() {
         history.push({
             grid: JSON.parse(JSON.stringify(grid)),
             colorGrid: JSON.parse(JSON.stringify(colorGrid)),
-            touchedGrid: JSON.parse(JSON.stringify(touchedGrid)),
             pulses: JSON.parse(JSON.stringify(pulses))
         });
         if (history.length > HISTORY_LIMIT) {
@@ -124,6 +163,7 @@ function update() {
         // Clone the current grid so we can apply pulses without altering
         // the original during iteration.
         const next = grid.map(row => row.slice());
+        const nextColors = colorGrid.map(row => row.slice());
         const pulsed = new Set();
         // In the old implementation every cell was recalculated here,
         // forcing a full-frame flicker. Now we only modify cells affected
@@ -131,28 +171,30 @@ function update() {
         pulses.forEach(p => {
             if (p.r >= 0 && p.r < rows && p.c >= 0 && p.c < cols) {
                 next[p.r][p.c] = p.remaining % 2;
+                nextColors[p.r][p.c] = p.color;
                 pulsed.add(p.r + ',' + p.c);
-                if (!touchedGrid[p.r][p.c]) {
-                    colorGrid[p.r][p.c] = p.color;
-                    touchedGrid[p.r][p.c] = true;
-                }
                 p.remaining--;
                 if (p.remaining <= 0) {
-                    touchedGrid[p.r][p.c] = false;
-                    colorGrid[p.r][p.c] = '#000000';
                     next[p.r][p.c] = 0;
+                    nextColors[p.r][p.c] = '#000000';
                 }
             }
         });
+        // Apply neighbor-based color evolution
+        const evolvedGrid = next.map(row => row.slice());
+        const evolvedColors = nextColors.map(row => row.slice());
         for (let r = 0; r < rows; r++) {
             for (let c = 0; c < cols; c++) {
-                if (touchedGrid[r][c] && !pulsed.has(r + ',' + c)) {
-                    next[r][c] = 1 - next[r][c];
-                }
+                if (pulsed.has(r + ',' + c)) continue;
+                const neighbors = getNeighbors(next, nextColors, r, c);
+                const { state, color } = getNextCellState({ state: next[r][c], color: nextColors[r][c] }, neighbors);
+                evolvedGrid[r][c] = state;
+                evolvedColors[r][c] = color;
             }
         }
         pulses = pulses.filter(p => p.remaining > 0);
-        grid = next;
+        grid = evolvedGrid;
+        colorGrid = evolvedColors;
         pulseCounter++;
     }
     drawGrid();
@@ -163,16 +205,13 @@ function applyTool(r, c) {
     if (tool === 'brush') {
         grid[r][c] = 1;
         colorGrid[r][c] = currentColor;
-        touchedGrid[r][c] = true;
     } else if (tool === 'eraser') {
         grid[r][c] = 0;
         colorGrid[r][c] = '#000000';
-        touchedGrid[r][c] = false;
     } else if (tool === 'pulse') {
         const len = parseInt(pulseLengthInput.value) || 1;
         grid[r][c] = 1;                 // start active
         colorGrid[r][c] = currentColor; // display chosen color
-        touchedGrid[r][c] = true;
         pulses.push({ r, c, remaining: len * 2 - 1, color: currentColor });
     } else if (tool === 'stamper') {
         const pattern = patterns.find(p => p.name === patternSelect.value);
@@ -182,7 +221,6 @@ function applyTool(r, c) {
                 const nc = (c + dc + cols) % cols;
                 grid[nr][nc] = 1;
                 colorGrid[nr][nc] = currentColor;
-                touchedGrid[nr][nc] = true;
             });
         }
     }


### PR DESCRIPTION
## Summary
- evolve cell color state based on neighbors
- display active cell colors directly
- update README for new behavior

## Testing
- `node -c public/app.js`

------
https://chatgpt.com/codex/tasks/task_e_686b7aaaa9bc8330b4a9ef7e1cc99803