### PR TITLE
Add adjustable neighbor activation threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ This project contains a simple pulse simulation playground. Open `index.html` in
    - **Pattern Stamper** – stamp a saved pattern at the clicked location. Use **Save Pattern** to store the current live cells.
 5. Choose the **Mode**:
    - **pulse** – cells only change from injected pulses or manual edits.
-   - **neighbor** – each step applies `f(n) = ((n + 1)^2) % 2` using the cell and its neighbors.
+   - **neighbor** – each step turns on a cell when the number of active neighbors matches the **Neighbor Count** setting.
+6. Select the **Neighbor Count** from 0–8 to control how many active neighbors are required for a cell to activate.
 
 Use the **Reverse** button to step backward through previous pulses. A color picker lets you choose the color for brush strokes, injected pulses and stamped patterns.
 

--- a/index.html
+++ b/index.html
@@ -23,6 +23,19 @@
                 <option value="neighbor">neighbor</option>
             </select>
         </label>
+        <label>Neighbor Count:
+            <select id="neighborSelect">
+                <option value="0">0</option>
+                <option value="1">1</option>
+                <option value="2">2</option>
+                <option value="3" selected>3</option>
+                <option value="4">4</option>
+                <option value="5">5</option>
+                <option value="6">6</option>
+                <option value="7">7</option>
+                <option value="8">8</option>
+            </select>
+        </label>
     </div>
 
     <div id="tools">

--- a/public/app.js
+++ b/public/app.js
@@ -19,6 +19,7 @@ const colorPicker = document.getElementById('colorPicker');
 const pulseCounterSpan = document.getElementById('pulseCounter');
 const reverseBtn = document.getElementById('reverseBtn');
 const modeSelect = document.getElementById('modeSelect');
+const neighborSelect = document.getElementById('neighborSelect');
 let currentColor = colorPicker.value;
 
 let cellSize = parseInt(zoomSlider.value);
@@ -35,6 +36,7 @@ let pulseCounter = 0;
 let reverse = false;
 let history = [];
 let mode = 'pulse';
+let neighborThreshold = parseInt(neighborSelect.value);
 
 function updateDimensions() {
     cellSize = parseInt(zoomSlider.value);
@@ -80,7 +82,7 @@ function drawGrid() {
 }
 
 function getNeighborsSum(r, c) {
-    let sum = grid[r][c];
+    let sum = 0;
     for (let dr = -1; dr <= 1; dr++) {
         for (let dc = -1; dc <= 1; dc++) {
             if (dr === 0 && dc === 0) continue;
@@ -113,7 +115,7 @@ function update() {
                 const row = [];
                 for (let c = 0; c < cols; c++) {
                     const n = getNeighborsSum(r, c);
-                    row.push(((n + 1) ** 2) % 2);
+                    row.push(n === neighborThreshold ? 1 : 0);
                 }
                 next.push(row);
             }
@@ -235,6 +237,7 @@ function init() {
     pulseCounterSpan.textContent = pulseCounter;
     reverseBtn.textContent = 'Reverse';
     mode = modeSelect.value;
+    neighborThreshold = parseInt(neighborSelect.value);
 }
 
 window.addEventListener('resize', () => {
@@ -265,6 +268,10 @@ colorPicker.addEventListener('input', () => {
 
 modeSelect.addEventListener('change', () => {
     mode = modeSelect.value;
+});
+
+neighborSelect.addEventListener('change', () => {
+    neighborThreshold = parseInt(neighborSelect.value);
 });
 
 reverseBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add a dropdown to set neighbor count threshold
- store neighbor threshold in JS and update it when the dropdown changes
- compute neighbor sums excluding the cell itself
- activate a cell only when the neighbor sum equals the selected threshold
- document the new Neighbor Count setting

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686ba8d9eeac8330b6a3fb4f58bd6b8c