### PR TITLE
Add neighbor slider value display

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This project contains a simple pulse simulation playground. Open `index.html` in
 5. Adjust the **Neighbor Count** slider (0–8) to control when a cell becomes active:
    - **0** – every cell simply flips state each tick.
    - **1–8** – a cell turns on only when it has exactly that many live neighbors.
+   The chosen value appears next to the slider.
 
 Use the **Reverse** button to step backward through previous pulses. A color picker lets you choose the color for brush strokes, injected pulses and stamped patterns.
 

--- a/index.html
+++ b/index.html
@@ -17,7 +17,10 @@
         <label>Zoom: <input type="range" id="zoomSlider" min="1" max="50" step="1" value="10"></label>
         <div id="pulseCounterDisplay">Pulse: <span id="pulseCounter">0</span></div>
         <button id="reverseBtn">Reverse</button>
-        <label>Neighbor Count: <input type="range" id="neighborSlider" min="0" max="8" step="1" value="0"></label>
+        <label>Neighbor Count:
+            <span id="neighborValue">0</span>
+            <input type="range" id="neighborSlider" min="0" max="8" step="1" value="0">
+        </label>
     </div>
 
     <div id="tools">

--- a/public/app.js
+++ b/public/app.js
@@ -19,6 +19,7 @@ const colorPicker = document.getElementById('colorPicker');
 const pulseCounterSpan = document.getElementById('pulseCounter');
 const reverseBtn = document.getElementById('reverseBtn');
 const neighborSlider = document.getElementById('neighborSlider');
+const neighborValueSpan = document.getElementById('neighborValue');
 let currentColor = colorPicker.value;
 
 let cellSize = parseInt(zoomSlider.value);
@@ -234,6 +235,7 @@ function init() {
     pulseCounterSpan.textContent = pulseCounter;
     reverseBtn.textContent = 'Reverse';
     neighborThreshold = parseInt(neighborSlider.value);
+    neighborValueSpan.textContent = neighborSlider.value;
 }
 
 window.addEventListener('resize', () => {
@@ -264,6 +266,7 @@ colorPicker.addEventListener('input', () => {
 
 neighborSlider.addEventListener('input', () => {
     neighborThreshold = parseInt(neighborSlider.value);
+    neighborValueSpan.textContent = neighborSlider.value;
 });
 
 reverseBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- show the selected neighbor count beside the slider
- reflect slider value in the UI via JavaScript
- note display of neighbor count in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686bac61e64883309f952c4f6310f8a8