### PR TITLE
Enable drag painting and runtime editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project contains a simple pulse simulation playground. Open `index.html` in
 
 ## Usage
 
-1. Click cells on the grid to activate them.
+1. Click and drag on the grid to paint active cells, even while the simulation is running.
 2. Press **Start** to run the simulation or **Stop** to pause.
 3. Adjust **Pulse Length**, **Fold Threshold** and **Zoom** with the sliders. A threshold of 0 disables folding and folded cells appear dark gray.
 4. Choose a tool from the **Tool** drop-down:

--- a/public/app.js
+++ b/public/app.js
@@ -243,8 +243,9 @@ function applyTool(r, c) {
 }
 // UI handlers
 
-function toggleCell(event) {
-    if (running) return;
+let isDrawing = false;
+
+function getCellFromEvent(event) {
     const rect = canvas.getBoundingClientRect();
     const scaleX = canvas.width / rect.width;
     const scaleY = canvas.height / rect.height;
@@ -252,9 +253,28 @@ function toggleCell(event) {
     const y = (event.clientY - rect.top) * scaleY;
     const c = Math.floor(x / cellSize);
     const r = Math.floor(y / cellSize);
+    return { r, c };
+}
+
+function toggleCell(event) {
+    const { r, c } = getCellFromEvent(event);
     if (r >= 0 && r < rows && c >= 0 && c < cols) {
         applyTool(r, c);
     }
+}
+
+function startDrawing(event) {
+    isDrawing = true;
+    toggleCell(event);
+}
+
+function drawIfNeeded(event) {
+    if (!isDrawing) return;
+    toggleCell(event);
+}
+
+function stopDrawing() {
+    isDrawing = false;
 }
 
 function start() {
@@ -360,7 +380,10 @@ reverseBtn.addEventListener('click', () => {
     reverseBtn.textContent = reverse ? 'Forward' : 'Reverse';
 });
 
-canvas.addEventListener('click', toggleCell);
+canvas.addEventListener('mousedown', startDrawing);
+canvas.addEventListener('mousemove', drawIfNeeded);
+canvas.addEventListener('mouseup', stopDrawing);
+canvas.addEventListener('mouseleave', stopDrawing);
 startBtn.addEventListener('click', start);
 stopBtn.addEventListener('click', stop);
 clearBtn.addEventListener('click', clearGrid);


### PR DESCRIPTION
## Summary
- allow clicking and dragging on the canvas to paint
- permit editing while the simulation is running
- document new drag feature in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bbc29a4e4833099abbe5c75ed2e71