### PR TITLE
Make zoom slider resize canvas

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -52,6 +52,8 @@ function updateDimensions() {
     rows = Math.floor(window.innerHeight / cellSize);
     canvas.width = cols * cellSize;
     canvas.height = rows * cellSize;
+    canvas.style.width = `${canvas.width}px`;
+    canvas.style.height = `${canvas.height}px`;
 }
 
 // Resize the canvas without recreating the grid
@@ -59,6 +61,8 @@ function updateCanvasSize() {
     cellSize = parseInt(zoomSlider.value);
     canvas.width = cols * cellSize;
     canvas.height = rows * cellSize;
+    canvas.style.width = `${canvas.width}px`;
+    canvas.style.height = `${canvas.height}px`;
 }
 
 function createGrid() {

--- a/public/style.css
+++ b/public/style.css
@@ -19,8 +19,6 @@ body {
 }
 
 #grid {
-    width: 100vw;
-    height: 100vh;
     background: #000;
     display: block;
 }


### PR DESCRIPTION
## Summary
- let canvas resize visually by matching CSS width/height
- remove forced viewport sizing in style sheet

## Testing
- `npm test` *(fails: could not read package.json)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_686bd0f12d7c8330be9a8d217c617bc1