### PR TITLE
Extend pattern save/load

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This scaffolding separates UI from simulation logic to allow future growth. Upco
 
 You can save the current pattern to a `.json` file and load it later without any backend:
 
-1. Enter a name in the **Pattern Name** field and click **Save Pattern**. A JSON file will be downloaded.
+1. Enter a name in the **Pattern Name** field and click **Save Pattern**. A JSON file containing the entire grid will be downloaded.
 2. Choose a saved pattern file with the file input and then click **Upload Pattern** to refresh the grid using its data.
 
 Everything runs entirely in the browser so no internet connection is required.

--- a/public/app.js
+++ b/public/app.js
@@ -343,14 +343,19 @@ function applyPatternData(data) {
         return;
     }
     clearGrid();
-    const size = data.pattern.length;
-    const half = Math.floor(size / 2);
+
+    const rowCount = data.rows || data.pattern.length;
+    const colCount = data.cols || (Array.isArray(data.pattern[0]) ? data.pattern[0].length : 0);
+    const halfRows = Math.floor(rowCount / 2);
+    const halfCols = Math.floor(colCount / 2);
     const pos = data.position || [Math.floor(rows / 2), Math.floor(cols / 2)];
-    for (let r = 0; r < size; r++) {
-        for (let c = 0; c < size; c++) {
-            const val = data.pattern[r][c];
-            const gr = pos[0] - half + r;
-            const gc = pos[1] - half + c;
+
+    for (let r = 0; r < rowCount; r++) {
+        const row = data.pattern[r] || [];
+        for (let c = 0; c < colCount; c++) {
+            const val = row[c] || 0;
+            const gr = pos[0] - halfRows + r;
+            const gc = pos[1] - halfCols + c;
             if (gr >= 0 && gr < rows && gc >= 0 && gc < cols) {
                 grid[gr][gc] = val;
                 if (val === 1) {
@@ -359,6 +364,7 @@ function applyPatternData(data) {
             }
         }
     }
+
     pulseCounter = data.pulse || 0;
     pulseCounterSpan.textContent = pulseCounter;
     drawGrid();
@@ -496,16 +502,17 @@ function saveCurrentPattern() {
     opt.textContent = name;
     patternSelect.appendChild(opt);
 
-    // Create JSON representation for offline use
-    const size = 10;
+    // Create JSON representation for offline use (entire grid)
     const centerR = Math.floor(rows / 2);
     const centerC = Math.floor(cols / 2);
-    const pattern = extractPatternSubgrid(centerR, centerC, size);
+    const pattern = grid.map(row => row.slice());
 
     const data = {
         name,
         pulse: pulseCounter || 0,
         position: [centerR, centerC],
+        rows,
+        cols,
         pattern
     };
 


### PR DESCRIPTION
## Summary
- allow rectangular pattern uploads and center them correctly
- export the entire grid when saving a pattern
- document that saved patterns capture the whole grid

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686bf3e909208330b015554f2c51948d