### PR TITLE
Move menu button to bottom

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -49,7 +49,7 @@ body {
 
 #menuToggle {
     position: absolute;
-    top: 10px;
+    bottom: 10px;
     right: 10px;
     z-index: 20;
     background: rgba(34, 34, 34, 0.8);
@@ -80,4 +80,22 @@ body {
 #slideMenu > div {
     position: static;
     margin-bottom: 20px;
+}
+
+@media (max-width: 600px) {
+    #slideMenu {
+        top: auto;
+        bottom: -260px;
+        right: 10px;
+        left: 10px;
+        width: auto;
+        height: auto;
+        max-height: 50vh;
+        transition: bottom 0.3s ease;
+    }
+
+    #slideMenu.open {
+        bottom: 60px;
+        right: 10px;
+    }
 }


### PR DESCRIPTION
## Summary
- move slide menu toggle to the bottom corner
- adapt slide menu layout on small screens

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686bfdbf4bc483308b421969867b8418