### PR TITLE
Add info sections and improve menu layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,32 @@
         <input type="file" id="patternLoader" accept=".json" onchange="handlePatternSelection(this)">
         <button id="patternUploadBtn" onclick="uploadPattern()" style="display:none">Upload Pattern</button>
     </div>
+
+    <div id="aboutInfo" class="infoSection">
+        <h2>About Pulse-Core</h2>
+        <p>Pulse-Core is a browser-based sandbox for experimenting with a simple pulse simulation. Cells flip on and off based on neighbor counts and optional folding logic. Draw patterns, inject pulses and watch the results in real time.</p>
+        <ul>
+            <li>Dynamic grid adapts with the zoom slider (capped at 500×500 cells).</li>
+            <li>Start/Stop controls with reverse stepping.</li>
+            <li>Adjust pulse length, folding threshold and neighbor count while running.</li>
+            <li>Brush, eraser, pulse injector and pattern stamper tools.</li>
+            <li>Color picker and optional flash effect.</li>
+            <li>Save patterns as JSON and reload them later.</li>
+            <li>Toggle debug numbers and grid lines.</li>
+        </ul>
+    </div>
+
+    <div id="usageInfo" class="infoSection">
+        <h2>How to Use</h2>
+        <ol>
+            <li>Open <code>index.html</code> in your browser.</li>
+            <li>Select a tool from the <strong>Tool</strong> dropdown and draw on the grid.</li>
+            <li>Press <strong>Start</strong> to animate the pattern and tweak the sliders as it runs.</li>
+            <li>Use <strong>Save Pattern</strong> to download your design or <strong>Upload Pattern</strong> to load a saved file.</li>
+            <li>The <strong>Reverse</strong> button steps backward through previous pulses.</li>
+        </ol>
+        <p>Once loaded, the tool works entirely offline.</p>
+    </div>
     </div>
     <canvas id="grid"></canvas>
 

--- a/public/style.css
+++ b/public/style.css
@@ -15,6 +15,15 @@ body {
     border-radius: 4px;
 }
 
+#controls label,
+#controls button,
+#controls select,
+#controls input,
+#controls div {
+    margin-top: 4px;
+    display: block;
+}
+
 #grid {
     background: #000;
     display: block;
@@ -45,6 +54,14 @@ body {
 #patternSaver button {
     margin-top: 4px;
     display: block;
+}
+
+.infoSection {
+    background: rgba(34, 34, 34, 0.8);
+    padding: 10px;
+    z-index: 10;
+    border-radius: 4px;
+    color: #eee;
 }
 
 #menuToggle {


### PR DESCRIPTION
## Summary
- show controls on separate lines for better readability
- add About and How to Use sections to the slide out menu
- style informational sections

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686bff52fafc833089a96979a7817794