### PR TITLE
Update menu layout and add info popups

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,17 +11,21 @@
     <button id="menuToggle">Menu</button>
     <div id="slideMenu">
     <div id="controls">
-        <button id="startBtn">Start</button>
-        <button id="stopBtn" disabled>Stop</button>
-        <button id="clearBtn">Clear</button>
+        <div id="controlButtons" class="controlRow">
+            <button id="startBtn">Start</button>
+            <button id="stopBtn" disabled>Stop</button>
+            <button id="clearBtn">Clear</button>
+        </div>
+        <div id="pulseRow" class="controlRow">
+            <div id="pulseCounterDisplay">Pulse: <span id="pulseCounter">0</span></div>
+            <button id="reverseBtn">Reverse</button>
+        </div>
         <label>Pulse Length: <input type="range" id="speedSlider" min="50" max="1000" step="50" value="500"></label>
         <label>Fold Threshold:
             <span id="foldValue">2</span>
             <input type="range" id="foldSlider" min="0" max="10" step="1" value="2">
         </label>
         <label>Zoom: <input type="range" id="zoomSlider" min="1" max="50" step="1" value="10"></label>
-        <div id="pulseCounterDisplay">Pulse: <span id="pulseCounter">0</span></div>
-        <button id="reverseBtn">Reverse</button>
         <label>Neighbor Count:
             <span id="neighborValue">2</span>
             <input type="range" id="neighborSlider" min="0" max="8" step="1" value="2">
@@ -29,6 +33,11 @@
         <label><input type="checkbox" id="debugOverlay"> Debug Overlay</label>
         <label><input type="checkbox" id="pulseFlash"> Pulse Flash</label>
         <label><input type="checkbox" id="gridLinesToggle" checked> Grid Lines</label>
+        <div id="infoLinks" class="controlRow">
+            <a href="#" id="aboutLink">About</a>
+            <span>|</span>
+            <a href="#" id="directionsLink">Directions</a>
+        </div>
     </div>
 
     <div id="tools">
@@ -54,7 +63,10 @@
         <button id="patternUploadBtn" onclick="uploadPattern()" style="display:none">Upload Pattern</button>
     </div>
 
-    <div id="aboutInfo" class="infoSection">
+    </div>
+
+    <div id="aboutPopup" class="popupOverlay infoSection">
+        <button class="closePopup">X</button>
         <h2>About Pulse-Core</h2>
         <p>Pulse-Core is a browser-based sandbox for experimenting with a simple pulse simulation. Cells flip on and off based on neighbor counts and optional folding logic. Draw patterns, inject pulses and watch the results in real time.</p>
         <ul>
@@ -68,7 +80,8 @@
         </ul>
     </div>
 
-    <div id="usageInfo" class="infoSection">
+    <div id="directionsPopup" class="popupOverlay infoSection">
+        <button class="closePopup">X</button>
         <h2>How to Use</h2>
         <ol>
             <li>Open <code>index.html</code> in your browser.</li>
@@ -79,7 +92,7 @@
         </ol>
         <p>Once loaded, the tool works entirely offline.</p>
     </div>
-    </div>
+
     <canvas id="grid"></canvas>
 
     <script src="public/app.js"></script>

--- a/public/app.js
+++ b/public/app.js
@@ -25,6 +25,11 @@ const pulseFlashCheckbox = document.getElementById('pulseFlash');
 const patternLoader = document.getElementById('patternLoader');
 const patternUploadBtn = document.getElementById('patternUploadBtn');
 const gridLinesToggle = document.getElementById('gridLinesToggle');
+const aboutLink = document.getElementById('aboutLink');
+const directionsLink = document.getElementById('directionsLink');
+const aboutPopup = document.getElementById('aboutPopup');
+const directionsPopup = document.getElementById('directionsPopup');
+const closeButtons = document.querySelectorAll('.closePopup');
 let currentColor = colorPicker.value;
 
 let cellSize = parseInt(zoomSlider.value);
@@ -637,6 +642,40 @@ canvas.addEventListener('mouseleave', stopDrawing);
 startBtn.addEventListener('click', start);
 stopBtn.addEventListener('click', stop);
 clearBtn.addEventListener('click', clearGrid);
+
+function openPopup(el) {
+    if (el) {
+        el.classList.add('show');
+    }
+}
+
+function closePopup(el) {
+    if (el) {
+        el.classList.remove('show');
+    }
+}
+
+if (aboutLink && aboutPopup) {
+    aboutLink.addEventListener('click', (e) => {
+        e.preventDefault();
+        openPopup(aboutPopup);
+    });
+}
+
+if (directionsLink && directionsPopup) {
+    directionsLink.addEventListener('click', (e) => {
+        e.preventDefault();
+        openPopup(directionsPopup);
+    });
+}
+
+if (closeButtons) {
+    closeButtons.forEach(btn => {
+        btn.addEventListener('click', () => {
+            closePopup(btn.parentElement);
+        });
+    });
+}
 
 const menuToggle = document.getElementById('menuToggle');
 const slideMenu = document.getElementById('slideMenu');

--- a/public/style.css
+++ b/public/style.css
@@ -24,6 +24,22 @@ body {
     display: block;
 }
 
+#controlButtons,
+#pulseRow {
+    display: flex;
+    gap: 6px;
+}
+
+#pulseRow {
+    align-items: center;
+}
+
+#infoLinks {
+    display: flex;
+    gap: 6px;
+    margin-top: 4px;
+}
+
 #grid {
     background: #000;
     display: block;
@@ -115,4 +131,34 @@ body {
         bottom: 60px;
         right: 10px;
     }
+}
+
+.popupOverlay {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(34, 34, 34, 0.95);
+    padding: 20px;
+    border-radius: 4px;
+    z-index: 30;
+    max-width: 80%;
+    max-height: 80%;
+    overflow-y: auto;
+    display: none;
+}
+
+.popupOverlay.show {
+    display: block;
+}
+
+.popupOverlay .closePopup {
+    position: absolute;
+    top: 5px;
+    right: 8px;
+    background: transparent;
+    color: #eee;
+    border: none;
+    font-size: 18px;
+    cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- reorganize Start/Stop/Clear controls on one line
- display pulse counter and Reverse button on a second line
- add "About" and "Directions" links that open pop-out dialogs
- implement pop-up styles and handlers

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686c00e108008330934ffda0fb81e83a