### PR TITLE
Move zoom control below pulse length

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,11 +21,11 @@
             <button id="reverseBtn">Reverse</button>
         </div>
         <label>Pulse Length: <input type="range" id="speedSlider" min="50" max="1000" step="50" value="500"></label>
+        <label>Zoom: <input type="range" id="zoomSlider" min="1" max="50" step="1" value="10"></label>
         <label>Fold Threshold:
             <span id="foldValue">2</span>
             <input type="range" id="foldSlider" min="0" max="10" step="1" value="2">
         </label>
-        <label>Zoom: <input type="range" id="zoomSlider" min="1" max="50" step="1" value="10"></label>
         <label>Neighbor Count:
             <span id="neighborValue">2</span>
             <input type="range" id="neighborSlider" min="0" max="8" step="1" value="2">


### PR DESCRIPTION
## Summary
- keep zoom slider grouped with pulse length in the menu

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686c044ff42483309228aaf79b3d7a4c