### PR TITLE
Add right‑click erase

### DIFF
--- a/ABOUT.md
+++ b/ABOUT.md
@@ -7,7 +7,7 @@ Pulse-Core is a browser-based sandbox that lets you play with a simple pulse sim
 - **Dynamic grid** – Each cell toggles between on and off as the simulation runs. Grid size adapts with the zoom slider but is capped at 500×500 cells.
 - **Start/Stop controls** – Start, stop and step backward through pulses with dedicated buttons.
 - **Adjustable behavior** – Tune pulse length, folding threshold and neighbor count while the simulation is running.
-- **Multiple tools** – Brush, eraser, pulse injector and pattern stamper let you build and experiment with different configurations.
+- **Multiple tools** – Brush, pulse injector and pattern stamper let you build and experiment with different configurations. Right-click cells to erase.
 - **Color picker and flash** – Choose a color for new cells and optionally flash between pulses.
 - **Pattern saving** – Save the entire grid to a JSON file for offline use and reload it later.
 - **Debug and grid options** – Toggle a numeric overlay or hide grid lines to change the display.
@@ -15,7 +15,7 @@ Pulse-Core is a browser-based sandbox that lets you play with a simple pulse sim
 ## Using the Tool
 
 1. Open `index.html` in your browser. The grid fills the page.
-2. Select a tool from the **Tool** dropdown and draw directly on the grid.
+2. Select a tool from the **Tool** dropdown and draw directly on the grid. Right-click to erase cells.
 3. Press **Start** to animate the pattern. Adjust sliders and options to see how the behavior changes.
 4. Use **Save Pattern** to download your creation or load a previously saved `.json` file with **Upload Pattern**.
 5. The **Reverse** button walks backward through prior pulses.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Pulse-Core is a browser-based sandbox for experimenting with a simple pulse simu
 - **Interactive grid** – Click and drag to paint cells even while the simulation runs.
 - **Start/Stop controls** – Run or pause the pulse engine at any time.
 - **Adjustable sliders** – Tune pulse length, fold threshold, zoom level and neighbor count on the fly.
-- **Tool selection** – Switch between brush, eraser, pulse injector and pattern stamper.
+- **Tool selection** – Switch between brush, pulse injector and pattern stamper. Right-click cells to erase.
 - **Color picker** – Choose the color used for brush strokes, injected pulses and stamped patterns.
 - **Reverse stepping** – Walk backward through up to 200 prior pulses.
 - **Pattern saving** – Download the entire grid as a JSON file and reload it later with the upload option.
@@ -18,7 +18,7 @@ The grid automatically resizes with your browser window but will not exceed 500�
 ## Running the Simulation
 
 1. Open `index.html` in your browser.
-2. Select a tool and draw directly on the canvas.
+2. Select a tool and draw directly on the canvas. Right-click to erase cells.
 3. Press **Start** to begin pulsing; **Stop** pauses the animation.
 4. Adjust sliders and checkboxes to experiment with different behaviors.
 5. Save your design with **Save Pattern** or restore a previous one with **Upload Pattern**.

--- a/index.html
+++ b/index.html
@@ -44,7 +44,6 @@
         <label>Tool:
             <select id="toolSelect">
                 <option value="brush">Brush</option>
-                <option value="eraser">Eraser</option>
                 <option value="pulse">Pulse Injector</option>
                 <option value="stamper">Pattern Stamper</option>
             </select>
@@ -73,7 +72,7 @@
             <li>Dynamic grid adapts with the zoom slider (capped at 500×500 cells).</li>
             <li>Start/Stop controls with reverse stepping.</li>
             <li>Adjust pulse length, folding threshold and neighbor count while running.</li>
-            <li>Brush, eraser, pulse injector and pattern stamper tools.</li>
+            <li>Brush, pulse injector and pattern stamper tools. Right-click any cell to erase.</li>
             <li>Color picker and optional flash effect.</li>
             <li>Save patterns as JSON and reload them later.</li>
             <li>Toggle debug numbers and grid lines.</li>
@@ -85,7 +84,7 @@
         <h2>How to Use</h2>
         <ol>
             <li>Open <code>index.html</code> in your browser.</li>
-            <li>Select a tool from the <strong>Tool</strong> dropdown and draw on the grid.</li>
+            <li>Select a tool from the <strong>Tool</strong> dropdown and draw on the grid. Right-click to erase cells.</li>
             <li>Press <strong>Start</strong> to animate the pattern and tweak the sliders as it runs.</li>
             <li>Use <strong>Save Pattern</strong> to download your design or <strong>Upload Pattern</strong> to load a saved file.</li>
             <li>The <strong>Reverse</strong> button steps backward through previous pulses.</li>

--- a/public/app.js
+++ b/public/app.js
@@ -399,11 +399,6 @@ function applyTool(r, c) {
         foldGrid[r][c] = 0;
         lastStateGrid[r][c] = 1;
         flickerCountGrid[r][c] = 0;
-    } else if (tool === 'eraser') {
-        grid[r][c] = 0;
-        foldGrid[r][c] = 0;
-        lastStateGrid[r][c] = 0;
-        flickerCountGrid[r][c] = 0;
     } else if (tool === 'pulse') {
         const len = parseInt(pulseLengthInput.value) || 1;
         pulses.push({ r, c, remaining: len * 2, color: currentColor });
@@ -430,6 +425,14 @@ function applyTool(r, c) {
     }
     drawGrid();
 }
+
+function eraseCell(r, c) {
+    grid[r][c] = 0;
+    foldGrid[r][c] = 0;
+    lastStateGrid[r][c] = 0;
+    flickerCountGrid[r][c] = 0;
+    drawGrid();
+}
 // UI handlers
 
 let isDrawing = false;
@@ -448,16 +451,23 @@ function getCellFromEvent(event) {
 function toggleCell(event) {
     const { r, c } = getCellFromEvent(event);
     if (r >= 0 && r < rows && c >= 0 && c < cols) {
-        applyTool(r, c);
+        const rightClick = event.buttons === 2 || event.button === 2;
+        if (rightClick) {
+            eraseCell(r, c);
+        } else {
+            applyTool(r, c);
+        }
     }
 }
 
 function startDrawing(event) {
+    event.preventDefault();
     isDrawing = true;
     toggleCell(event);
 }
 
 function drawIfNeeded(event) {
+    event.preventDefault();
     if (!isDrawing) return;
     toggleCell(event);
 }
@@ -639,6 +649,7 @@ canvas.addEventListener('mousedown', startDrawing);
 canvas.addEventListener('mousemove', drawIfNeeded);
 canvas.addEventListener('mouseup', stopDrawing);
 canvas.addEventListener('mouseleave', stopDrawing);
+canvas.addEventListener('contextmenu', e => e.preventDefault());
 startBtn.addEventListener('click', start);
 stopBtn.addEventListener('click', stop);
 clearBtn.addEventListener('click', clearGrid);


### PR DESCRIPTION
## Summary
- remove eraser option from the UI and docs
- allow right-click to erase cells
- document right-click erase behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686c0b372a948330925466ed9bf67812