### PR TITLE
Move info links inside slide menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,11 +33,6 @@
         <label><input type="checkbox" id="debugOverlay"> Debug Overlay</label>
         <label><input type="checkbox" id="pulseFlash"> Pulse Flash</label>
         <label><input type="checkbox" id="gridLinesToggle" checked> Grid Lines</label>
-        <div id="infoLinks" class="controlRow">
-            <a href="#" id="aboutLink">About</a>
-            <span>|</span>
-            <a href="#" id="directionsLink">Directions</a>
-        </div>
     </div>
 
     <div id="tools">
@@ -60,6 +55,12 @@
         <button onclick="saveCurrentPattern()">💾 Save Pattern</button>
         <input type="file" id="patternLoader" accept=".json" onchange="handlePatternSelection(this)">
         <button id="patternUploadBtn" onclick="uploadPattern()" style="display:none">Upload Pattern</button>
+    </div>
+
+    <div id="infoLinks" class="controlRow">
+        <a href="#" id="aboutLink">About</a>
+        <span>|</span>
+        <a href="#" id="directionsLink">Directions</a>
     </div>
 
     </div>

--- a/public/style.css
+++ b/public/style.css
@@ -38,6 +38,10 @@ body {
     display: flex;
     gap: 6px;
     margin-top: 4px;
+    margin-bottom: 0;
+    position: absolute;
+    bottom: 10px;
+    left: 10px;
 }
 #infoLinks a {
     color: #fff;


### PR DESCRIPTION
## Summary
- position the About/Directions links at the bottom-left of the slide-out menu

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686c0e7ebeac8330a47ac8533e21fb3d