### PR TITLE
Fix zoom slider to fill canvas

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -65,14 +65,10 @@ const MAX_DIMENSION = 500;
 let pulseFlash = true;
 
 function updateZoom() {
+    // Update the pixel size for each cell based on the zoom slider
+    // and refresh the grid dimensions so the canvas remains filled.
     cellSize = parseInt(zoomSlider.value);
-    if (centerView) {
-        offsetX = Math.floor((canvas.width - cols * cellSize) / 2);
-        offsetY = Math.floor((canvas.height - rows * cellSize) / 2);
-    } else {
-        offsetX = 0;
-        offsetY = 0;
-    }
+    updateDimensions();
 }
 
 function updateDimensions() {


### PR DESCRIPTION
## Summary
- update zoom logic so changing the slider recomputes grid dimensions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686c9dd028008330828384b3b8af9267