### PR TITLE
Limit randomize grid size

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Pulse-Core is a browser-based sandbox for experimenting with a simple pulse simu
 
 - **Interactive grid** – Click and drag to paint cells even while the simulation runs.
 - **Start/Stop controls** – Run or pause the pulse engine at any time.
-- **Randomize button** – Generate a new 50×50 grid of random cells.
+- **Randomize button** – Generate a centered 4×5 grid of 20 px cells with no more than 80% filled.
 - **Adjustable sliders** – Tune pulse length, fold threshold, zoom level and neighbor count on the fly.
 - **Tool selection** – Switch between brush, pulse injector and pattern stamper. Right-click cells to erase.
 - **Color picker** – Choose the color used for brush strokes, injected pulses and stamped patterns.
@@ -25,7 +25,7 @@ Adjusting the zoom slider now scales the existing grid so it always fills the wi
 3. Press **Start** to begin pulsing; **Stop** pauses the animation.
 4. Adjust sliders and checkboxes to experiment with different behaviors.
 5. Save your design with **Save Pattern** or restore a previous one with **Upload Pattern**.
-6. Use **Randomize** to fill a new 50×50 grid with random values.
+6. Use **Randomize** to drop a centered 4×5 grid of 20 px cells with a random fill up to 80%.
 
 Everything happens client-side, so once loaded you can use the tool without an internet connection.
 

--- a/public/app.js
+++ b/public/app.js
@@ -587,16 +587,26 @@ function clearGrid() {
 
 function randomizeGrid() {
     stop();
-    rows = 50;
-    cols = 50;
-    cellSize = 10;
+    rows = 4;
+    cols = 5;
+    cellSize = 20;
     zoomSlider.value = cellSize;
-    canvas.width = cols * cellSize;
-    canvas.height = rows * cellSize;
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+    offsetX = Math.floor((canvas.width - cols * cellSize) / 2);
+    offsetY = Math.floor((canvas.height - rows * cellSize) / 2);
     createGrid();
+    const maxFill = Math.floor(rows * cols * 0.8);
+    const fillProb = Math.random() * 0.8;
+    let filled = 0;
     for (let r = 0; r < rows; r++) {
         for (let c = 0; c < cols; c++) {
-            grid[r][c] = Math.random() < 0.5 ? 1 : 0;
+            if (filled < maxFill && Math.random() < fillProb) {
+                grid[r][c] = 1;
+                filled++;
+            } else {
+                grid[r][c] = 0;
+            }
         }
     }
     drawGrid();


### PR DESCRIPTION
## Summary
- center random grid generation and limit to 4x5 squares
- document new grid size in README

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cb47191a88330b72f7ee3ffa96972