### PR TITLE
Update collapse threshold units

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Pulse-Core is a browser-based sandbox for experimenting with a simple pulse simu
 - **Interactive grid** – Click and drag to paint cells even while the simulation runs.
 - **Start/Stop controls** – Run or pause the pulse engine at any time.
 - **Randomize button** – Fill the entire field with random cells using the current grid size.
-- **Adjustable sliders** – Tune pulse length, fold threshold, zoom level, neighbor count and collapse threshold on the fly.
+- **Adjustable sliders** – Tune pulse length, fold threshold, zoom level, neighbor count and collapse threshold (in Pulse Units) on the fly.
 - **Tool selection** – Switch between brush, pulse injector and pattern stamper. Right-click cells to erase.
 - **Color picker** – Choose the color used for brush strokes, injected pulses and stamped patterns.
 - **Reverse stepping** – Walk backward through up to 200 prior pulses.
@@ -23,7 +23,7 @@ Adjusting the zoom slider now scales the existing grid so it always fills the wi
 1. Open `index.html` in your browser.
 2. Select a tool and draw directly on the canvas. Right-click to erase cells.
 3. Press **Start** to begin pulsing; **Stop** pauses the animation.
-4. Adjust sliders and checkboxes to experiment with different behaviors. The collapse threshold controls how much energy accumulates before the field clears.
+4. Adjust sliders and checkboxes to experiment with different behaviors. The collapse threshold (in Pulse Units) controls how much energy accumulates before the field clears.
 5. Save your design with **Save Pattern** or restore a previous one with **Upload Pattern**.
 6. Use **Randomize** to populate the current grid with randomly placed cells.
 

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
         </div>
         <label>Frame Rate: <input type="range" id="frameRateSlider" min="50" max="1000" step="50" value="500"></label>
         <div id="tensionDisplay">Tension: <span id="tensionValue">0</span></div>
-        <label>Collapse Threshold: <input type="number" id="thresholdInput" min="100" value="1000"></label>
+        <label>Collapse Threshold (Pulse Units): <input type="number" id="thresholdInput" value="1.5" step="0.1"></label>
         <label>Zoom: <input type="range" id="zoomSlider" min="1" max="50" step="1" value="10"></label>
         <label>Fold Threshold:
             <span id="foldValue">2</span>

--- a/public/app.js
+++ b/public/app.js
@@ -65,7 +65,7 @@ let neighborThreshold = parseInt(neighborSlider.value);
 let debugOverlay = false;
 let fieldTensionMode = 'none';
 let activeCellCount = 0;
-let collapseThreshold = parseInt(thresholdInput.value || '1000');
+let collapseThreshold = parseFloat(thresholdInput.value || '1.5') * 10000;
 let showGridLines = true;
 let centerView = false;
 let offsetX = 0;
@@ -798,7 +798,7 @@ pulseLengthInput.addEventListener('input', () => {
 });
 
 thresholdInput.addEventListener('input', () => {
-    collapseThreshold = parseInt(thresholdInput.value || '1000');
+    collapseThreshold = parseFloat(thresholdInput.value || '1.5') * 10000;
 });
 
 frameRateSlider.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- show collapse threshold in Pulse Units in UI
- scale threshold value by 10,000 when reading it
- document Pulse Unit usage

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc78442f88330b06a5d60ec83c168