### PR TITLE
Implement Info Nova burst and overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Pulse-Core is a browser-based sandbox for experimenting with a simple pulse simu
 - **Pattern saving** – Download the entire grid as a JSON file and reload it later with the upload option.
 - **Optional overlays** – Toggle pulse flash, field tension mapping and grid lines.
 - **Center View option** – Keep the field centered while zooming or resizing.
+- **Info Nova** – If accumulated energy exceeds the collapse threshold, the grid
+  clears, explodes from the center and the simulation restarts.
 
 The grid automatically resizes with your browser window but will not exceed 500×500 cells for performance reasons.
 Adjusting the zoom slider now scales the existing grid so it always fills the window.
@@ -24,6 +26,7 @@ Adjusting the zoom slider now scales the existing grid so it always fills the wi
 2. Select a tool and draw directly on the canvas. Right-click to erase cells.
 3. Press **Start** to begin pulsing; **Stop** pauses the animation.
 4. Adjust sliders and checkboxes to experiment with different behaviors. The collapse threshold (in Pulse Units) controls how much energy accumulates before the field clears.
+5. When the threshold is crossed, an **Info Nova** burst clears the grid, shows a brief message and resumes from frame 0.
 5. Save your design with **Save Pattern** or restore a previous one with **Upload Pattern**.
 6. Use **Randomize** to populate the current grid with randomly placed cells.
 
@@ -38,6 +41,8 @@ npm install
 npm run lint
 npm test
 ```
+
+Run `npm install` once before running the tests to ensure Jest is available.
 
 `npm test` currently outputs a placeholder message but establishes a spot for future tests.
 

--- a/index.html
+++ b/index.html
@@ -105,10 +105,11 @@
             <li>Use <strong>Save Pattern</strong> to download your design or <strong>Upload Pattern</strong> to load a saved file.</li>
             <li>The <strong>Reverse</strong> button steps backward through previous pulses.</li>
         </ol>
-        <p>Once loaded, the tool works entirely offline.</p>
+    <p>Once loaded, the tool works entirely offline.</p>
     </div>
 
     <canvas id="grid"></canvas>
+    <div id="novaOverlay">INFO NOVA</div>
 
     <script type="module" src="public/app.js"></script>
 </body>

--- a/public/app.js
+++ b/public/app.js
@@ -44,6 +44,7 @@ const directionsLink = document.getElementById('directionsLink');
 const aboutPopup = document.getElementById('aboutPopup');
 const directionsPopup = document.getElementById('directionsPopup');
 const closeButtons = document.querySelectorAll('.closePopup');
+const novaOverlay = document.getElementById('novaOverlay');
 let currentColor = colorPicker.value;
 
 let cellSize = parseInt(zoomSlider.value);
@@ -685,28 +686,40 @@ function triggerBigBang() {
 }
 
 function triggerInfoNova() {
-    const centerX = Math.floor(grid.length / 2);
-    const centerY = Math.floor(grid[0].length / 2);
+    const centerX = Math.floor(rows / 2);
+    const centerY = Math.floor(cols / 2);
 
     clearGrid(false);
 
-    grid[centerX][centerY] = 1;
+    const foldThreshold = parseInt(foldSlider.value);
+    const radius = Math.max(2, pulseLength) + neighborThreshold + foldThreshold;
 
-    const flicker = pulseCounter % 2;
-    for (let radius = 1; radius <= pulseLength; radius++) {
-        for (let angle = 0; angle < 360; angle += 45) {
-            const x = Math.floor(centerX + radius * Math.cos(angle * Math.PI / 180));
-            const y = Math.floor(centerY + radius * Math.sin(angle * Math.PI / 180));
-            if (grid[x] && grid[x][y] !== undefined) {
-                grid[x][y] = flicker;
+    for (let dr = -radius; dr <= radius; dr++) {
+        for (let dc = -radius; dc <= radius; dc++) {
+            const dist = Math.sqrt(dr * dr + dc * dc);
+            if (dist <= radius) {
+                const r = centerX + dr;
+                const c = centerY + dc;
+                if (r >= 0 && r < rows && c >= 0 && c < cols) {
+                    grid[r][c] = 1;
+                    colorGrid[r][c] = currentColor;
+                }
             }
         }
     }
 
     accumulatedEnergy = 0;
     pulseCounter = 0;
+    prevGrid = copyGrid(grid);
+    drawGrid();
+
+    if (novaOverlay) {
+        novaOverlay.classList.add('show');
+        setTimeout(() => novaOverlay.classList.remove('show'), 1200);
+    }
 
     console.log('Info Nova at', new Date().toISOString());
+    start();
 }
 
 function saveCurrentPattern() {
@@ -933,3 +946,5 @@ if (menuToggle && slideMenu) {
 
 init();
 // Additional hooks for pulse direction and substrate density will be added later.
+
+export { triggerInfoNova };

--- a/public/style.css
+++ b/public/style.css
@@ -179,3 +179,23 @@ canvas.flash {
     from { background: #fff; }
     to { background: inherit; }
 }
+
+#novaOverlay {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 48px;
+    color: #fff;
+    pointer-events: none;
+    opacity: 0;
+}
+
+#novaOverlay.show {
+    animation: nova-fade 1.5s ease-out forwards;
+}
+
+@keyframes nova-fade {
+    from { opacity: 1; }
+    to { opacity: 0; }
+}

--- a/tests/infonova.test.js
+++ b/tests/infonova.test.js
@@ -1,0 +1,28 @@
+import { triggerInfoNova } from '../public/app.js';
+
+// Mock minimal globals used by triggerInfoNova
+beforeEach(() => {
+    global.rows = 5;
+    global.cols = 5;
+    global.grid = Array.from({ length: rows }, () => Array(cols).fill(0));
+    global.colorGrid = Array.from({ length: rows }, () => Array(cols).fill('#fff'));
+    global.neighborThreshold = 1;
+    global.pulseLength = 2;
+    global.foldSlider = { value: '0' };
+    global.currentColor = '#00ff00';
+    global.clearGrid = () => {};
+    global.copyGrid = (src) => src.map(r => r.slice());
+    global.drawGrid = () => {};
+    global.start = () => {};
+    global.accumulatedEnergy = 123;
+    global.pulseCounter = 5;
+});
+
+test('triggerInfoNova resets counter and activates center cell', () => {
+    triggerInfoNova();
+    expect(pulseCounter).toBe(0);
+    const midR = Math.floor(rows / 2);
+    const midC = Math.floor(cols / 2);
+    expect(grid[midR][midC]).toBe(1);
+});
+


### PR DESCRIPTION
## Summary
- show Info Nova overlay on the canvas
- compute Info Nova radius from current settings and restart automatically
- expose `triggerInfoNova` for tests
- document the Info Nova collapse event and mention `npm install`
- add basic unit test for Info Nova behaviour

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cd72b556c8330a6c9c2b46630ab6b