### PR TITLE
Add configurable Info Nova genesis modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Pulse-Core is a browser-based sandbox for experimenting with a simple pulse simu
 - **Center View option** – Keep the field centered while zooming or resizing.
 - **Info Nova** – If accumulated energy exceeds the collapse threshold, the grid
   clears, explodes from the center and the simulation restarts.
+- **Genesis Mode** – Choose how Info Nova seeds cells on restart: stable, chaotic, organic, fractal or seeded.
 
 The grid automatically resizes with your browser window but will not exceed 500×500 cells for performance reasons.
 Adjusting the zoom slider now scales the existing grid so it always fills the window.


### PR DESCRIPTION
## Summary
- introduce `genesisMode` global to control Info Nova starting patterns
- generate nova start patterns based on five modes
- export `genesisMode` for tests
- document the new Genesis Mode feature in README

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ceae1e8b88330bcf2454059cd7509