### PR TITLE
Add Genesis Mode selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,14 @@
             <input type="range" id="neighborSlider" min="0" max="8" step="1" value="2">
         </label>
         <label id="pulseLengthLabel">Pulse Length: <input type="number" id="pulseLength" value="3" min="1" /></label>
+        <label for="genesisModeSelect">Genesis Mode:</label>
+        <select id="genesisModeSelect">
+            <option value="stable">Stable</option>
+            <option value="chaotic">Chaotic</option>
+            <option value="organic">Organic</option>
+            <option value="fractal">Fractal</option>
+            <option value="seeded">Seeded</option>
+        </select>
         <label><input type="checkbox" id="debugOverlay"> Field Tension Mapping</label>
         <select id="fieldTensionMode" style="margin-top:4px">
             <option value="none" selected>None</option>

--- a/public/app.js
+++ b/public/app.js
@@ -38,6 +38,7 @@ const pulseFlashCheckbox = document.getElementById('pulseFlash');
 const patternLoader = document.getElementById('patternLoader');
 const patternUploadBtn = document.getElementById('patternUploadBtn');
 const gridLinesToggle = document.getElementById('gridLinesToggle');
+const genesisSelect = document.getElementById('genesisModeSelect');
 const centerViewToggle = document.getElementById('centerViewToggle');
 const aboutLink = document.getElementById('aboutLink');
 const directionsLink = document.getElementById('directionsLink');
@@ -958,6 +959,7 @@ function init() {
     foldValueSpan.textContent = foldSlider.value;
     debugOverlay = debugCheckbox.checked;
     fieldTensionMode = fieldTensionDropdown ? fieldTensionDropdown.value : 'none';
+    genesisMode = genesisSelect ? genesisSelect.value : 'stable';
 }
 
 window.addEventListener('resize', () => {
@@ -1018,6 +1020,12 @@ if (fieldTensionDropdown) {
     fieldTensionDropdown.addEventListener('change', () => {
         fieldTensionMode = fieldTensionDropdown.value;
         drawGrid();
+    });
+}
+
+if (genesisSelect) {
+    genesisSelect.addEventListener('change', (e) => {
+        genesisMode = e.target.value;
     });
 }
 


### PR DESCRIPTION
## Summary
- add Genesis Mode selector dropdown in UI
- connect selector to simulation logic and store selected mode

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cf4243d248330a818dbfc5d520304