### PR TITLE
Move genesis mode selector UI and log selected mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,16 @@
     <button id="menuToggle">Menu</button>
     <div id="slideMenu">
     <div id="controls">
+        <div id="genesisRow" class="controlRow">
+            <label for="genesisModeSelect">Genesis Mode:</label>
+            <select id="genesisModeSelect">
+                <option value="stable">Stable</option>
+                <option value="chaotic">Chaotic</option>
+                <option value="organic">Organic</option>
+                <option value="fractal">Fractal</option>
+                <option value="seeded">Seeded</option>
+            </select>
+        </div>
         <div id="controlButtons" class="controlRow">
             <button id="startBtn">Start</button>
             <button id="stopBtn" disabled>Stop</button>
@@ -33,14 +43,6 @@
             <input type="range" id="neighborSlider" min="0" max="8" step="1" value="2">
         </label>
         <label id="pulseLengthLabel">Pulse Length: <input type="number" id="pulseLength" value="3" min="1" /></label>
-        <label for="genesisModeSelect">Genesis Mode:</label>
-        <select id="genesisModeSelect">
-            <option value="stable">Stable</option>
-            <option value="chaotic">Chaotic</option>
-            <option value="organic">Organic</option>
-            <option value="fractal">Fractal</option>
-            <option value="seeded">Seeded</option>
-        </select>
         <label><input type="checkbox" id="debugOverlay"> Field Tension Mapping</label>
         <select id="fieldTensionMode" style="margin-top:4px">
             <option value="none" selected>None</option>

--- a/public/app.js
+++ b/public/app.js
@@ -784,6 +784,8 @@ function triggerInfoNova() {
         seedFractal(cr, cc + rad, Math.floor(rad / 2));
     }
 
+    console.log('Using genesis mode:', genesisMode);
+
     switch (genesisMode) {
     case 'chaotic': {
         while (placed < maxCells) {

--- a/public/style.css
+++ b/public/style.css
@@ -25,7 +25,8 @@ body {
 }
 
 #controlButtons,
-#pulseRow {
+#pulseRow,
+#genesisRow {
     display: flex;
     gap: 6px;
 }


### PR DESCRIPTION
## Summary
- move the Genesis Mode dropdown to its own row at the top of the control panel
- add `#genesisRow` flex style for layout
- log the currently active genesis mode when a data nova occurs

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cf76663448330b645f78972d337e7