### PR TITLE
Remove auto-trigger of Data Nova

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,9 +123,8 @@
 
     <script type="module" src="public/app.js"></script>
     <script type="module">
-        import { init, triggerInfoNova } from './public/app.js';
+        import { init } from './public/app.js';
         init();
-        triggerInfoNova();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- stop calling `triggerInfoNova` when the page loads

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d0501c0fc8330be99af3c66fec160