### PR TITLE
Update Data Nova overlay layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
     </div>
 
     <canvas id="grid"></canvas>
-    <div id="novaOverlay">DATA NOVA</div>
+    <div id="novaOverlay">Data Nova</div>
 
     <script type="module" src="public/app.js"></script>
     <script type="module">

--- a/public/app.js
+++ b/public/app.js
@@ -855,7 +855,8 @@ function triggerInfoNova() {
 
     console.log('Seeding: ' + genesisMode);
     if (novaOverlay) {
-        novaOverlay.textContent = 'DATA NOVA — Seeding: ' + genesisMode;
+        const modeDisplay = genesisMode.charAt(0).toUpperCase() + genesisMode.slice(1);
+        novaOverlay.innerHTML = modeDisplay + '<br>Data Nova';
     }
 
     switch (genesisMode) {
@@ -888,7 +889,7 @@ function triggerInfoNova() {
         novaOverlay.classList.add('show');
         setTimeout(() => {
             novaOverlay.classList.remove('show');
-            novaOverlay.textContent = 'DATA NOVA';
+            novaOverlay.textContent = 'Data Nova';
         }, 1200);
     }
 

--- a/public/style.css
+++ b/public/style.css
@@ -186,6 +186,7 @@ canvas.flash {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+    text-align: center;
     font-size: 48px;
     color: #fff;
     pointer-events: none;


### PR DESCRIPTION
## Summary
- center the Data Nova text overlay on multiple lines
- display genesis mode above "Data Nova" text

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d088fa16883308b69fce78f17d7dc