### PR TITLE
Move Pre-Pulse label and simplify status text

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <button id="menuToggle">Menu</button>
     <div id="slideMenu">
     <div id="controls">
+        <div id="stateLabel">State: Pre-Pulse</div>
         <div id="genesisRow" class="controlRow">
             <label for="genesisModeSelect">Genesis Mode:</label>
             <select id="genesisModeSelect">
@@ -29,7 +30,6 @@
         </div>
         <div id="pulseRow" class="controlRow">
             <div id="pulseCounterDisplay">Frame: <span id="pulseCounter">0</span></div>
-            <div id="stateLabel">State: Pre-Pulse</div>
             <button id="reverseBtn">Reverse</button>
         </div>
         <label>Frame Rate: <input type="range" id="frameRateSlider" min="50" max="1000" step="50" value="500"></label>

--- a/public/app.js
+++ b/public/app.js
@@ -350,7 +350,7 @@ function update() {
         timeElapsed = 0;
         pulseCounter = 1;
         pulseCounterSpan.textContent = pulseCounter;
-        stateLabel.textContent = `State: Pulsing (Frame ${pulseCounter})`;
+        stateLabel.textContent = 'State: Pulsing';
         stateLabel.classList.add('pulse-start');
         setTimeout(() => stateLabel.classList.remove('pulse-start'), 300);
         frameDurationSpan.textContent = '0';
@@ -432,7 +432,7 @@ function update() {
     }
     drawGrid();
     pulseCounterSpan.textContent = pulseCounter;
-    stateLabel.textContent = `State: Pulsing (Frame ${pulseCounter})`;
+    stateLabel.textContent = 'State: Pulsing';
     activeCellCount = countActiveCells(grid);
     tensionValueSpan.textContent = activeCellCount;
     const complexity = countCellChanges(prevGrid, grid);
@@ -542,7 +542,7 @@ function applyPatternData(data) {
 
     pulseCounter = data.pulse || 0;
     pulseCounterSpan.textContent = pulseCounter;
-    stateLabel.textContent = pulseCounter === 0 ? 'State: Pre-Pulse' : `State: Pulsing (Frame ${pulseCounter})`;
+    stateLabel.textContent = pulseCounter === 0 ? 'State: Pre-Pulse' : 'State: Pulsing';
     drawGrid();
 }
 


### PR DESCRIPTION
## Summary
- move the state label to the top of the control menu
- stop including the frame count in the pulsing state text

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d092e07588330a97cfb87e2a1cb87