### PR TITLE
Add paused state to simulation

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -655,6 +655,7 @@ function stop() {
     stopBtn.disabled = true;
     pulseLengthInput.disabled = false;
     clearInterval(intervalId);
+    stateLabel.textContent = 'State: Paused';
 }
 
 function clearGrid(resetStats = true) {


### PR DESCRIPTION
## Summary
- show `State: Paused` when the simulation stops

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d0a3dd58c8330b86df3a885de6c41