### PR TITLE
Implement Genesis Phase toggle and multi-nova logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ Pulse-Core is a browser-based sandbox for experimenting with a simple pulse simu
 - **Pattern saving** – Download the entire grid as a JSON file and reload it later with the upload option.
 - **Optional overlays** – Toggle pulse flash, field tension mapping and grid lines.
 - **Center View option** – Keep the field centered while zooming or resizing.
-- **Data Nova** – If accumulated energy exceeds the collapse threshold, the grid
-  clears, explodes from the center and the simulation restarts.
+ - **Data Nova** – If accumulated energy exceeds the collapse threshold, the grid
+  clears and one or more novas explode from the densest regions before the simulation restarts.
 - **Genesis Mode** – Choose how Data Nova seeds cells on restart: stable, chaotic, organic, fractal or seeded.
+- **Genesis Phase** – Decide whether multiple novas collapse in Pre-Pulse (manual selection) or Post-Pulse (automatic) mode.
 
 The grid automatically resizes with your browser window. Use the **Resolution Limit** slider to cap the maximum grid size (250–2000 cells per side). Values above 800 display a warning as high resolutions may impact performance.
 Adjusting the zoom slider now scales the existing grid so it always fills the window.
@@ -42,6 +43,10 @@ When a **Data Nova** occurs, the selected genesis mode seeds the initial pattern
 - **Organic** – Forms a wavy cluster using a sine-based curve.
 - **Fractal** – Recursively lays out cells in a fractal cross pattern.
 - **Seeded** – Loads a user-defined pattern from memory.
+
+The **Genesis Phase** toggle determines whether, when multiple dense regions tie,
+you select one origin before the first frame (Pre-Pulse) or all activate automatically
+after the pulse begins (Post-Pulse).
 
 The current mode is displayed on screen and logged to the console whenever seeding happens.
 
@@ -69,7 +74,7 @@ Once the packages are installed you can execute the test suite with:
 npm test
 ```
 
-`npm test` currently outputs a placeholder message but establishes a spot for future tests.
+`npm test` runs the Jest suite which validates multi-nova logic, genesis modes and other utilities.
 
 The project is released under the MIT License (see `LICENSE`).
 

--- a/index.html
+++ b/index.html
@@ -22,6 +22,13 @@
                 <option value="seeded">Seeded</option>
             </select>
         </div>
+        <div id="genesisPhaseRow" class="controlRow">
+            <label>Genesis Phase:</label>
+            <input type="radio" name="genesisPhase" id="prePhase" value="pre" checked>
+            <label for="prePhase">Pre-Pulse 🌌</label>
+            <input type="radio" name="genesisPhase" id="postPhase" value="post">
+            <label for="postPhase">Post-Pulse ⚡</label>
+        </div>
         <div id="controlButtons" class="controlRow">
             <button id="startBtn">Start</button>
             <button id="stopBtn" disabled>Stop</button>

--- a/tests/datanova.test.js
+++ b/tests/datanova.test.js
@@ -1,5 +1,5 @@
 let triggerInfoNova;
-let latestNovaCenter;
+let latestNovaCenters;
 
 // Mock minimal globals used by triggerInfoNova
 beforeEach(async () => {
@@ -14,7 +14,7 @@ beforeEach(async () => {
     `;
     const mod = await import('../public/app.js');
     triggerInfoNova = mod.triggerInfoNova;
-    latestNovaCenter = mod.latestNovaCenter;
+    latestNovaCenters = mod.latestNovaCenters;
     global.rows = 8;
     global.cols = 8;
     global.grid = Array.from({ length: rows }, () => Array(cols).fill(0));
@@ -45,15 +45,15 @@ beforeEach(async () => {
 test('triggerInfoNova picks origin in densest cluster', () => {
     triggerInfoNova();
     expect(pulseCounter).toBe(0);
-    expect(latestNovaCenter[0]).toBeGreaterThan(4);
-    expect(latestNovaCenter[1]).toBeGreaterThan(4);
+    expect(latestNovaCenters[0][0]).toBeGreaterThan(4);
+    expect(latestNovaCenters[0][1]).toBeGreaterThan(4);
 });
 
 test('triggerInfoNova uses single active cell as center', () => {
     global.prevGrid = Array.from({ length: rows }, () => Array(cols).fill(0));
     prevGrid[3][4] = 1;
     triggerInfoNova();
-    expect(latestNovaCenter).toEqual([3, 4]);
+    expect(latestNovaCenters[0]).toEqual([3, 4]);
 });
 
 test('triggerInfoNova averages position when density is tied', () => {
@@ -61,6 +61,15 @@ test('triggerInfoNova averages position when density is tied', () => {
     prevGrid[0][0] = 1;
     prevGrid[7][7] = 1;
     triggerInfoNova();
-    expect(latestNovaCenter).toEqual([3, 3]);
+    expect(latestNovaCenters[0]).toEqual([3, 3]);
+});
+
+test('triggerInfoNova detects multiple isolated clusters', () => {
+    global.prevGrid = Array.from({ length: rows }, () => Array(cols).fill(0));
+    prevGrid[0][0] = 1;
+    prevGrid[7][7] = 1;
+    prevGrid[0][7] = 1;
+    triggerInfoNova();
+    expect(latestNovaCenters.length).toBeGreaterThan(1);
 });
 

--- a/tests/genesisMode.test.js
+++ b/tests/genesisMode.test.js
@@ -1,5 +1,5 @@
 let triggerInfoNova;
-let latestNovaCenter;
+let latestNovaCenters;
 
 beforeEach(async () => {
     jest.resetModules();
@@ -13,7 +13,7 @@ beforeEach(async () => {
     `;
     const mod = await import('../public/app.js');
     triggerInfoNova = mod.triggerInfoNova;
-    latestNovaCenter = mod.latestNovaCenter;
+    latestNovaCenters = mod.latestNovaCenters;
     global.rows = 20;
     global.cols = 20;
     global.grid = Array.from({ length: rows }, () => Array(cols).fill(0));
@@ -34,7 +34,7 @@ beforeEach(async () => {
 test('stable genesis creates centered square', () => {
     global.genesisMode = 'stable';
     triggerInfoNova();
-    const [r0, c0] = latestNovaCenter;
+    const [r0, c0] = latestNovaCenters[0];
     let active = 0;
     for (let r = r0 - 5; r <= r0 + 5; r++) {
         for (let c = c0 - 5; c <= c0 + 5; c++) {
@@ -50,7 +50,7 @@ test('stable genesis creates centered square', () => {
 test('seeded genesis creates cross', () => {
     global.genesisMode = 'seeded';
     triggerInfoNova();
-    const [r0, c0] = latestNovaCenter;
+    const [r0, c0] = latestNovaCenters[0];
     const coords = [
         [r0, c0],
         [r0 - 1, c0],

--- a/tests/genesisPhase.test.js
+++ b/tests/genesisPhase.test.js
@@ -1,0 +1,15 @@
+import { init, lockGenesisPhase, genesisPhase } from '../public/app.js';
+
+document.body.innerHTML = `
+    <input type="radio" name="genesisPhase" id="prePhase" value="pre" checked>
+    <input type="radio" name="genesisPhase" id="postPhase" value="post">
+`;
+
+test('lockGenesisPhase disables phase radios', () => {
+    init();
+    lockGenesisPhase();
+    const pre = document.getElementById('prePhase');
+    const post = document.getElementById('postPhase');
+    expect(pre.disabled).toBe(true);
+    expect(post.disabled).toBe(true);
+});

--- a/tests/tension.test.js
+++ b/tests/tension.test.js
@@ -1,7 +1,12 @@
-import { countActiveCells } from '../public/tension.js';
+import { countActiveCells, shouldBigBang } from '../public/tension.js';
 
 test('countActiveCells counts non-zero cells', () => {
     const g = [ [1,0], [0,2] ];
     expect(countActiveCells(g)).toBe(2);
+});
+
+test('shouldBigBang detects threshold', () => {
+    expect(shouldBigBang(10, 2, 4)).toBe(true);
+    expect(shouldBigBang(3, 2, 2)).toBe(false);
 });
 


### PR DESCRIPTION
## Summary
- add Pre-/Post-Pulse selector in the menu
- lock Genesis Phase after the first pulse
- support clustering of tied regions and multi-nova origins
- expose latestNovaCenters and add selection UI
- update tests for new behaviour and add new ones
- clarify README about Jest tests

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d80de53ac83309d7eecb0f41699d1