### PR TITLE
Add Post-Pulse toggle and Nova info popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,10 +24,8 @@
         </div>
         <div id="genesisPhaseRow" class="controlRow">
             <label>Genesis Phase:</label>
-            <input type="radio" name="genesisPhase" id="prePhase" value="pre" checked>
-            <label for="prePhase">Pre-Pulse 🌌</label>
-            <input type="radio" name="genesisPhase" id="postPhase" value="post">
-            <label for="postPhase">Post-Pulse ⚡</label>
+            <input type="checkbox" id="postPhaseToggle">
+            <label for="postPhaseToggle">Post-Pulse ⚡</label>
         </div>
         <div id="controlButtons" class="controlRow">
             <button id="startBtn">Start</button>
@@ -129,6 +127,7 @@
 
     <canvas id="grid"></canvas>
     <div id="novaOverlay">Data Nova</div>
+    <div id="novaInfoBox" class="popupOverlay novaInfo"></div>
 
     <script type="module" src="public/app.js"></script>
     <script type="module">

--- a/public/style.css
+++ b/public/style.css
@@ -202,6 +202,21 @@ canvas.flash {
     to { opacity: 0; }
 }
 
+#novaInfoBox {
+    position: absolute;
+    background: rgba(34, 34, 34, 0.95);
+    padding: 10px;
+    border-radius: 4px;
+    color: #eee;
+    z-index: 40;
+    display: none;
+    transform: translate(-50%, -50%);
+}
+
+#novaInfoBox.show {
+    display: block;
+}
+
 #resolutionWarning {
     color: #f88;
     font-weight: bold;

--- a/tests/genesisPhase.test.js
+++ b/tests/genesisPhase.test.js
@@ -1,15 +1,12 @@
-import { init, lockGenesisPhase, genesisPhase } from '../public/app.js';
+import { init, lockGenesisPhase } from '../public/app.js';
 
 document.body.innerHTML = `
-    <input type="radio" name="genesisPhase" id="prePhase" value="pre" checked>
-    <input type="radio" name="genesisPhase" id="postPhase" value="post">
+    <input type="checkbox" id="postPhaseToggle">
 `;
 
-test('lockGenesisPhase disables phase radios', () => {
+test('lockGenesisPhase disables phase toggle', () => {
     init();
     lockGenesisPhase();
-    const pre = document.getElementById('prePhase');
-    const post = document.getElementById('postPhase');
-    expect(pre.disabled).toBe(true);
-    expect(post.disabled).toBe(true);
+    const toggle = document.getElementById('postPhaseToggle');
+    expect(toggle.disabled).toBe(true);
 });

--- a/tests/novaInfo.test.js
+++ b/tests/novaInfo.test.js
@@ -1,0 +1,27 @@
+import * as mod from '../public/app.js';
+
+document.body.innerHTML = `
+    <canvas id="grid"></canvas>
+    <div id="novaInfoBox"></div>
+`;
+
+const canvas = document.getElementById('grid');
+canvas.width = 100;
+canvas.height = 100;
+
+global.canvas = canvas;
+global.cellSize = 10;
+global.offsetX = 0;
+global.offsetY = 0;
+
+global.drawGrid = jest.fn();
+
+test('showNovaInfo displays box and centers on click', () => {
+    const spy = jest.spyOn(mod, 'centerOnNova');
+    mod.showNovaInfo([2, 3]);
+    const box = document.getElementById('novaInfoBox');
+    expect(box.classList.contains('show')).toBe(true);
+    document.getElementById('focusNovaBtn').click();
+    expect(spy).toHaveBeenCalledWith([2, 3]);
+    expect(box.classList.contains('show')).toBe(false);
+});


### PR DESCRIPTION
## Summary
- replace Pre/Post radio group with single Post‑Pulse checkbox
- disable/enable the new toggle in `lockGenesisPhase`
- show nova details via `showNovaInfo` and allow centering with `centerOnNova`
- call the info dialog when running in Post‑Pulse phase
- add CSS for the dialog positioning
- update unit tests and add new test for nova info

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d93b1435c83309cdde2be0095b6c1