### PR TITLE
Allow nova selection when genesis phase is post

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -925,6 +925,40 @@ function triggerInfoNova() {
         return;
     }
 
+    if (genesisPhase === 'post' && latestNovaCenters.length > 1) {
+        selectionPending = true;
+        stop();
+        drawGrid();
+        if (novaOverlay) {
+            novaOverlay.textContent = 'Choose Nova';
+            novaOverlay.classList.add('show');
+        }
+        const handler = (e) => {
+            if (!selectionPending) return;
+            const rect = canvas.getBoundingClientRect();
+            const x = e.clientX - rect.left - offsetX;
+            const y = e.clientY - rect.top - offsetY;
+            const r = Math.floor(y / cellSize);
+            const c = Math.floor(x / cellSize);
+            let chosen = null;
+            let best = Infinity;
+            latestNovaCenters.forEach(pt => {
+                const d = Math.hypot(pt[0] - r, pt[1] - c);
+                if (d < best) { best = d; chosen = pt; }
+            });
+            if (chosen) {
+                selectionPending = false;
+                canvas.removeEventListener('click', handler);
+                latestNovaCenters = [chosen];
+                latestNovaCenter = chosen;
+                novaOverlay.classList.remove('show');
+                performNovaSequence();
+            }
+        };
+        canvas.addEventListener('click', handler);
+        return;
+    }
+
     performNovaSequence();
 
     function performNovaSequence() {


### PR DESCRIPTION
## Summary
- allow nova selection in post phase when multiple novas are detected

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9aecd8c88330bd6ce9994f6e6456