### PR TITLE
Fix nova selection overlay

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -897,9 +897,10 @@ function triggerInfoNova() {
         selectionPending = true;
         stop();
         drawGrid();
+        showNovaInfo(latestNovaCenters[0]);
         if (novaOverlay) {
             novaOverlay.textContent = 'Choose Timeline';
-            novaOverlay.classList.add('show');
+            novaOverlay.classList.add('prompt', 'show');
         }
         const handler = (e) => {
             if (!selectionPending) return;
@@ -919,7 +920,9 @@ function triggerInfoNova() {
                 canvas.removeEventListener('click', handler);
                 latestNovaCenters = [chosen];
                 latestNovaCenter = chosen;
-                novaOverlay.classList.remove('show');
+                novaOverlay.classList.remove('prompt', 'show');
+                const info = document.getElementById('novaInfoBox');
+                if (info) info.classList.remove('show');
                 performNovaSequence();
             }
         };
@@ -931,9 +934,10 @@ function triggerInfoNova() {
         selectionPending = true;
         stop();
         drawGrid();
+        showNovaInfo(latestNovaCenters[0]);
         if (novaOverlay) {
             novaOverlay.textContent = 'Choose Nova';
-            novaOverlay.classList.add('show');
+            novaOverlay.classList.add('prompt', 'show');
         }
         const handler = (e) => {
             if (!selectionPending) return;
@@ -953,7 +957,9 @@ function triggerInfoNova() {
                 canvas.removeEventListener('click', handler);
                 latestNovaCenters = [chosen];
                 latestNovaCenter = chosen;
-                novaOverlay.classList.remove('show');
+                novaOverlay.classList.remove('prompt', 'show');
+                const info = document.getElementById('novaInfoBox');
+                if (info) info.classList.remove('show');
                 performNovaSequence();
             }
         };

--- a/public/style.css
+++ b/public/style.css
@@ -197,6 +197,11 @@ canvas.flash {
     animation: nova-fade 1.5s ease-out forwards;
 }
 
+#novaOverlay.prompt {
+    opacity: 1;
+    animation: none;
+}
+
 @keyframes nova-fade {
     from { opacity: 1; }
     to { opacity: 0; }

--- a/tests/novaSelection.test.js
+++ b/tests/novaSelection.test.js
@@ -1,0 +1,44 @@
+let triggerInfoNova;
+let mod;
+
+beforeEach(async () => {
+    jest.resetModules();
+    document.body.innerHTML = `
+        <canvas id="grid"></canvas>
+        <button id="startBtn"></button>
+        <button id="stopBtn"></button>
+        <input id="frameRateSlider" value="100" />
+        <input id="pulseLength" value="2" />
+        <div id="novaOverlay"></div>
+        <div id="novaInfoBox"></div>
+    `;
+    mod = await import('../public/app.js');
+    triggerInfoNova = mod.triggerInfoNova;
+    global.rows = 8;
+    global.cols = 8;
+    global.grid = Array.from({ length: rows }, () => Array(cols).fill(0));
+    global.colorGrid = Array.from({ length: rows }, () => Array(cols).fill('#fff'));
+    global.neighborThreshold = 1;
+    global.pulseLength = 2;
+    global.foldSlider = { value: '0' };
+    global.currentColor = '#00ff00';
+    global.genesisMode = 'stable';
+    global.clearGrid = () => {};
+    global.copyGrid = (src) => src.map(r => r.slice());
+    global.drawGrid = () => {};
+    global.start = () => {};
+    global.accumulatedEnergy = 100;
+    global.pulseCounter = 0;
+    global.genesisPhase = 'pre';
+    global.prevGrid = Array.from({ length: rows }, () => Array(cols).fill(0));
+    prevGrid[0][0] = 1;
+    prevGrid[7][7] = 1;
+});
+
+test('triggerInfoNova shows info box when selection begins', () => {
+    const spy = jest.spyOn(mod, 'showNovaInfo');
+    triggerInfoNova();
+    expect(spy).toHaveBeenCalled();
+    const box = document.getElementById('novaInfoBox');
+    expect(box.classList.contains('show')).toBe(true);
+});


### PR DESCRIPTION
## Summary
- keep nova overlay visible while selecting
- open nova info when selection starts and hide it after
- test overlay and info box selection behavior

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da532cea083309f71e4bd3e185d57