### PR TITLE
Enable multiple nova info boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The current mode is displayed on screen and logged to the console whenever seedi
 
 ## Development
 
-This repository uses ESLint for basic linting. Install dependencies and run:
+This repository uses ESLint for basic linting. Install dependencies first and then run:
 
 ```sh
 npm install

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
 
     <canvas id="grid"></canvas>
     <div id="novaOverlay">Data Nova</div>
-    <div id="novaInfoBox" class="popupOverlay novaInfo"></div>
+    <div id="novaInfoContainer"></div>
 
     <script type="module" src="public/app.js"></script>
     <script type="module">

--- a/public/app.js
+++ b/public/app.js
@@ -897,7 +897,7 @@ function triggerInfoNova() {
         selectionPending = true;
         stop();
         drawGrid();
-        showNovaInfo(latestNovaCenters[0]);
+        latestNovaCenters.forEach(showNovaInfo);
         if (novaOverlay) {
             novaOverlay.textContent = 'Choose Timeline';
             novaOverlay.classList.add('prompt', 'show');
@@ -921,8 +921,7 @@ function triggerInfoNova() {
                 latestNovaCenters = [chosen];
                 latestNovaCenter = chosen;
                 novaOverlay.classList.remove('prompt', 'show');
-                const info = document.getElementById('novaInfoBox');
-                if (info) info.classList.remove('show');
+                hideNovaInfoBoxes();
                 performNovaSequence();
             }
         };
@@ -934,7 +933,7 @@ function triggerInfoNova() {
         selectionPending = true;
         stop();
         drawGrid();
-        showNovaInfo(latestNovaCenters[0]);
+        latestNovaCenters.forEach(showNovaInfo);
         if (novaOverlay) {
             novaOverlay.textContent = 'Choose Nova';
             novaOverlay.classList.add('prompt', 'show');
@@ -958,8 +957,7 @@ function triggerInfoNova() {
                 latestNovaCenters = [chosen];
                 latestNovaCenter = chosen;
                 novaOverlay.classList.remove('prompt', 'show');
-                const info = document.getElementById('novaInfoBox');
-                if (info) info.classList.remove('show');
+                hideNovaInfoBoxes();
                 performNovaSequence();
             }
         };
@@ -970,6 +968,7 @@ function triggerInfoNova() {
     performNovaSequence();
 
     function performNovaSequence() {
+        hideNovaInfoBoxes();
         clearGrid(false);
         console.log('Seeding: ' + genesisMode);
         if (novaOverlay) {
@@ -1003,7 +1002,7 @@ function triggerInfoNova() {
         prevGrid = copyGrid(grid);
         drawGrid();
         if (genesisPhase === 'post') {
-            showNovaInfo(latestNovaCenter);
+            latestNovaCenters.forEach(showNovaInfo);
         }
         if (novaOverlay) {
             novaOverlay.classList.add('show');
@@ -1249,21 +1248,27 @@ function centerOnNova([r, c]) {
     drawGrid();
 }
 
+function hideNovaInfoBoxes() {
+    document.querySelectorAll('.novaInfoBox').forEach(el => el.remove());
+}
+
 function showNovaInfo(center) {
-    const box = document.getElementById('novaInfoBox');
-    if (!box || !center) return;
+    if (!center) return;
+    const container = document.getElementById('novaInfoContainer') || document.body;
+    const box = document.createElement('div');
+    box.className = 'popupOverlay novaInfo novaInfoBox show';
     const [r, c] = center;
     const x = c * cellSize + offsetX + cellSize / 2;
     const y = r * cellSize + offsetY + cellSize / 2;
     box.style.left = `${x}px`;
     box.style.top = `${y}px`;
-    box.innerHTML = `<div>Nova (${r}, ${c})</div><button id="focusNovaBtn">Center</button>`;
-    box.classList.add('show');
-    const btn = document.getElementById('focusNovaBtn');
+    box.innerHTML = `<div>Nova (${r}, ${c})</div><button class="focusNovaBtn">Center</button>`;
+    container.appendChild(box);
+    const btn = box.querySelector('.focusNovaBtn');
     if (btn) {
         btn.addEventListener('click', () => {
             centerOnNova(center);
-            box.classList.remove('show');
+            hideNovaInfoBoxes();
         }, { once: true });
     }
 }

--- a/public/style.css
+++ b/public/style.css
@@ -207,7 +207,8 @@ canvas.flash {
     to { opacity: 0; }
 }
 
-#novaInfoBox {
+#novaInfoContainer .novaInfoBox,
+.novaInfoBox {
     position: absolute;
     background: rgba(34, 34, 34, 0.95);
     padding: 10px;
@@ -218,7 +219,7 @@ canvas.flash {
     transform: translate(-50%, -50%);
 }
 
-#novaInfoBox.show {
+.novaInfoBox.show {
     display: block;
 }
 

--- a/tests/novaInfo.test.js
+++ b/tests/novaInfo.test.js
@@ -2,7 +2,7 @@ import * as mod from '../public/app.js';
 
 document.body.innerHTML = `
     <canvas id="grid"></canvas>
-    <div id="novaInfoBox"></div>
+    <div id="novaInfoContainer"></div>
 `;
 
 const canvas = document.getElementById('grid');
@@ -19,9 +19,10 @@ global.drawGrid = jest.fn();
 test('showNovaInfo displays box and centers on click', () => {
     const spy = jest.spyOn(mod, 'centerOnNova');
     mod.showNovaInfo([2, 3]);
-    const box = document.getElementById('novaInfoBox');
-    expect(box.classList.contains('show')).toBe(true);
-    document.getElementById('focusNovaBtn').click();
+    const boxes = document.querySelectorAll('.novaInfoBox');
+    expect(boxes.length).toBe(1);
+    expect(boxes[0].classList.contains('show')).toBe(true);
+    boxes[0].querySelector('.focusNovaBtn').click();
     expect(spy).toHaveBeenCalledWith([2, 3]);
-    expect(box.classList.contains('show')).toBe(false);
+    expect(document.querySelectorAll('.novaInfoBox').length).toBe(0);
 });

--- a/tests/novaSelection.test.js
+++ b/tests/novaSelection.test.js
@@ -10,7 +10,7 @@ beforeEach(async () => {
         <input id="frameRateSlider" value="100" />
         <input id="pulseLength" value="2" />
         <div id="novaOverlay"></div>
-        <div id="novaInfoBox"></div>
+        <div id="novaInfoContainer"></div>
     `;
     mod = await import('../public/app.js');
     triggerInfoNova = mod.triggerInfoNova;
@@ -35,10 +35,11 @@ beforeEach(async () => {
     prevGrid[7][7] = 1;
 });
 
-test('triggerInfoNova shows info box when selection begins', () => {
+test('triggerInfoNova shows an info box for each nova center', () => {
     const spy = jest.spyOn(mod, 'showNovaInfo');
     triggerInfoNova();
-    expect(spy).toHaveBeenCalled();
-    const box = document.getElementById('novaInfoBox');
-    expect(box.classList.contains('show')).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(2);
+    const boxes = document.querySelectorAll('.novaInfoBox');
+    expect(boxes.length).toBe(2);
+    boxes.forEach(box => expect(box.classList.contains('show')).toBe(true));
 });


### PR DESCRIPTION
## Summary
- support multiple simultaneous nova info boxes
- tweak UI styles for new `.novaInfoBox` elements
- document running `npm install` before lint/test
- update tests for multi-box behaviour

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686db0c747d883308cf35482888977e0