### PR TITLE
Fix nova box persistence and selection

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -893,7 +893,7 @@ function triggerInfoNova() {
     }
     latestNovaCenter = latestNovaCenters[0];
 
-    if (genesisPhase === 'pre' && pulseCounter === 0 && latestNovaCenters.length > 1) {
+    if (genesisPhase === 'pre' && latestNovaCenters.length > 1) {
         selectionPending = true;
         stop();
         drawGrid();
@@ -921,7 +921,6 @@ function triggerInfoNova() {
                 latestNovaCenters = [chosen];
                 latestNovaCenter = chosen;
                 novaOverlay.classList.remove('prompt', 'show');
-                hideNovaInfoBoxes();
                 performNovaSequence();
             }
         };
@@ -957,7 +956,6 @@ function triggerInfoNova() {
                 latestNovaCenters = [chosen];
                 latestNovaCenter = chosen;
                 novaOverlay.classList.remove('prompt', 'show');
-                hideNovaInfoBoxes();
                 performNovaSequence();
             }
         };
@@ -1001,9 +999,7 @@ function triggerInfoNova() {
         pulseCounter = 0;
         prevGrid = copyGrid(grid);
         drawGrid();
-        if (genesisPhase === 'post') {
-            latestNovaCenters.forEach(showNovaInfo);
-        }
+        latestNovaCenters.forEach(showNovaInfo);
         if (novaOverlay) {
             novaOverlay.classList.add('show');
             setTimeout(() => {
@@ -1268,8 +1264,7 @@ function showNovaInfo(center) {
     if (btn) {
         btn.addEventListener('click', () => {
             centerOnNova(center);
-            hideNovaInfoBoxes();
-        }, { once: true });
+        });
     }
 }
 

--- a/tests/novaInfo.test.js
+++ b/tests/novaInfo.test.js
@@ -24,5 +24,5 @@ test('showNovaInfo displays box and centers on click', () => {
     expect(boxes[0].classList.contains('show')).toBe(true);
     boxes[0].querySelector('.focusNovaBtn').click();
     expect(spy).toHaveBeenCalledWith([2, 3]);
-    expect(document.querySelectorAll('.novaInfoBox').length).toBe(0);
+    expect(document.querySelectorAll('.novaInfoBox').length).toBe(1);
 });


### PR DESCRIPTION
## Summary
- keep nova info boxes visible after choosing a nova
- allow nova choice on every cycle by removing pulse check
- always show nova info boxes after a Data Nova
- update nova tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686db47773708330902a9da24185999b