### PR TITLE
Remove inline pattern handlers

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,9 +84,9 @@
 
     <div id="patternSaver">
         <input type="text" id="patternName" placeholder="Pattern Name">
-        <button onclick="saveCurrentPattern()">💾 Save Pattern</button>
-        <input type="file" id="patternLoader" accept=".json" onchange="handlePatternSelection(this)">
-        <button id="patternUploadBtn" onclick="uploadPattern()" style="display:none">Upload Pattern</button>
+        <button id="patternSaverButton">💾 Save Pattern</button>
+        <input type="file" id="patternLoader" accept=".json">
+        <button id="patternUploadBtn" style="display:none">Upload Pattern</button>
     </div>
 
     <div id="infoLinks" class="controlRow">

--- a/public/app.js
+++ b/public/app.js
@@ -38,6 +38,7 @@ const fieldTensionDropdown = document.getElementById('fieldTensionMode');
 const pulseFlashCheckbox = document.getElementById('pulseFlash');
 const patternLoader = document.getElementById('patternLoader');
 const patternUploadBtn = document.getElementById('patternUploadBtn');
+const patternSaverButton = document.getElementById('patternSaverButton');
 const gridLinesToggle = document.getElementById('gridLinesToggle');
 const genesisSelect = document.getElementById('genesisModeSelect');
 const postPhaseToggle = document.getElementById('postPhaseToggle');
@@ -1233,6 +1234,18 @@ startBtn.addEventListener('click', start);
 stopBtn.addEventListener('click', stop);
 clearBtn.addEventListener('click', clearGrid);
 randomizeBtn.addEventListener('click', randomizeGrid);
+
+if (patternSaverButton) {
+    patternSaverButton.addEventListener('click', saveCurrentPattern);
+}
+
+if (patternLoader) {
+    patternLoader.addEventListener('change', (e) => handlePatternSelection(e.target));
+}
+
+if (patternUploadBtn) {
+    patternUploadBtn.addEventListener('click', uploadPattern);
+}
 
 function openPopup(el) {
     if (el) {


### PR DESCRIPTION
## Summary
- clean up inline event handlers for pattern saving and loading
- hook pattern buttons and file input via JS

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686df03d86f48330ad221a19a538bd3e