### PR TITLE
Enable automatic nova activation in post phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Pulse-Core is a browser-based sandbox for experimenting with a simple pulse simu
  - **Data Nova** – If accumulated energy exceeds the collapse threshold, the grid
   clears and one or more novas explode from the densest regions before the simulation restarts.
 - **Genesis Mode** – Choose how Data Nova seeds cells on restart: stable, chaotic, organic, fractal or seeded.
-- **Genesis Phase** – Decide whether multiple novas collapse in Pre-Pulse (manual selection) or Post-Pulse (automatic) mode.
+- **Genesis Phase** – Choose **Pre-Pulse** to manually pick a single nova when multiple centers tie, or **Post-Pulse** to automatically launch them all.
 
 The grid automatically resizes with your browser window. Use the **Resolution Limit** slider to cap the maximum grid size (250–2000 cells per side). Values above 800 display a warning as high resolutions may impact performance.
 Adjusting the zoom slider now scales the existing grid so it always fills the window.
@@ -45,9 +45,7 @@ When a **Data Nova** occurs, the selected genesis mode seeds the initial pattern
 - **Fractal** – Recursively lays out cells in a fractal cross pattern.
 - **Seeded** – Loads a user-defined pattern from memory.
 
-The **Genesis Phase** toggle determines whether, when multiple dense regions tie,
-you select one origin before the first frame (Pre-Pulse) or all activate automatically
-after the pulse begins (Post-Pulse).
+The **Genesis Phase** toggle controls multi-nova behavior. In **Pre-Pulse** mode you select a single origin when several dense regions compete. In **Post-Pulse** mode no selection occurs — every detected nova spawns automatically on restart.
 
 The current mode is displayed on screen and logged to the console whenever seeding happens.
 

--- a/public/app.js
+++ b/public/app.js
@@ -938,37 +938,8 @@ function triggerInfoNova() {
     }
 
     if (genesisPhase === 'post' && latestNovaCenters.length > 1) {
-        selectionPending = true;
-        stop();
-        drawGrid();
-        latestNovaCenters.forEach(showNovaInfo);
-        if (novaOverlay) {
-            novaOverlay.textContent = 'Choose Nova';
-            novaOverlay.classList.add('prompt', 'show');
-        }
-        const handler = (e) => {
-            if (!selectionPending) return;
-            const rect = canvas.getBoundingClientRect();
-            const x = e.clientX - rect.left - offsetX;
-            const y = e.clientY - rect.top - offsetY;
-            const r = Math.floor(y / cellSize);
-            const c = Math.floor(x / cellSize);
-            let chosen = null;
-            let best = Infinity;
-            latestNovaCenters.forEach(pt => {
-                const d = Math.hypot(pt[0] - r, pt[1] - c);
-                if (d < best) { best = d; chosen = pt; }
-            });
-            if (chosen) {
-                selectionPending = false;
-                canvas.removeEventListener('click', handler);
-                latestNovaCenters = [chosen];
-                latestNovaCenter = chosen;
-                novaOverlay.classList.remove('prompt', 'show');
-                performNovaSequence();
-            }
-        };
-        canvas.addEventListener('click', handler);
+        // In post phase multiple novas should trigger automatically
+        performNovaSequence();
         return;
     }
 

--- a/tests/postPhaseAuto.test.js
+++ b/tests/postPhaseAuto.test.js
@@ -1,0 +1,43 @@
+let triggerInfoNova;
+let mod;
+
+beforeEach(async () => {
+    jest.resetModules();
+    document.body.innerHTML = `
+        <canvas id="grid"></canvas>
+        <button id="startBtn"></button>
+        <button id="stopBtn"></button>
+        <input id="frameRateSlider" value="100" />
+        <input id="pulseLength" value="2" />
+        <div id="novaOverlay"></div>
+        <div id="novaInfoContainer"></div>
+    `;
+    mod = await import('../public/app.js');
+    triggerInfoNova = mod.triggerInfoNova;
+    global.rows = 8;
+    global.cols = 8;
+    global.grid = Array.from({ length: rows }, () => Array(cols).fill(0));
+    global.colorGrid = Array.from({ length: rows }, () => Array(cols).fill('#fff'));
+    global.neighborThreshold = 1;
+    global.pulseLength = 2;
+    global.foldSlider = { value: '0' };
+    global.currentColor = '#00ff00';
+    global.genesisMode = 'stable';
+    global.clearGrid = () => {};
+    global.copyGrid = (src) => src.map(r => r.slice());
+    global.drawGrid = () => {};
+    global.start = jest.fn();
+    global.accumulatedEnergy = 100;
+    global.pulseCounter = 0;
+    global.genesisPhase = 'post';
+    global.prevGrid = Array.from({ length: rows }, () => Array(cols).fill(0));
+    prevGrid[0][0] = 1;
+    prevGrid[7][7] = 1;
+});
+
+test('triggerInfoNova automatically seeds all novas in post phase', () => {
+    triggerInfoNova();
+    expect(global.start).toHaveBeenCalled();
+    const boxes = document.querySelectorAll('.novaInfoBox');
+    expect(boxes.length).toBe(2);
+});


### PR DESCRIPTION
## Summary
- simplify `triggerInfoNova` post phase logic so all novas trigger without user input
- clarify genesis phase behaviour in README
- add test covering automatic nova seeding when in post phase

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e0d2eeaa883308650bc4a8cadcee9