### PR TITLE
Swap nova selection behavior between phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Pulse-Core is a browser-based sandbox for experimenting with a simple pulse simu
  - **Data Nova** – If accumulated energy exceeds the collapse threshold, the grid
   clears and one or more novas explode from the densest regions before the simulation restarts.
 - **Genesis Mode** – Choose how Data Nova seeds cells on restart: stable, chaotic, organic, fractal or seeded.
-- **Genesis Phase** – Choose **Pre-Pulse** to manually pick a single nova when multiple centers tie, or **Post-Pulse** to automatically launch them all.
+- **Genesis Phase** – Choose **Pre-Pulse** to automatically launch all novas when multiple centers tie, or **Post-Pulse** to manually pick one before continuing.
 
 The grid automatically resizes with your browser window. Use the **Resolution Limit** slider to cap the maximum grid size (250–2000 cells per side). Values above 800 display a warning as high resolutions may impact performance.
 Adjusting the zoom slider now scales the existing grid so it always fills the window.
@@ -45,7 +45,7 @@ When a **Data Nova** occurs, the selected genesis mode seeds the initial pattern
 - **Fractal** – Recursively lays out cells in a fractal cross pattern.
 - **Seeded** – Loads a user-defined pattern from memory.
 
-The **Genesis Phase** toggle controls multi-nova behavior. In **Pre-Pulse** mode you select a single origin when several dense regions compete. In **Post-Pulse** mode no selection occurs — every detected nova spawns automatically on restart.
+The **Genesis Phase** toggle controls multi-nova behavior. In **Pre-Pulse** mode every detected nova launches automatically. In **Post-Pulse** mode the simulation pauses so you can choose a single origin when several dense regions compete.
 
 The current mode is displayed on screen and logged to the console whenever seeding happens.
 

--- a/public/app.js
+++ b/public/app.js
@@ -903,6 +903,13 @@ function triggerInfoNova() {
     }
 
     if (genesisPhase === 'pre' && latestNovaCenters.length > 1) {
+        // Pre phase now launches all novas immediately
+        performNovaSequence();
+        return;
+    }
+
+    if (genesisPhase === 'post' && latestNovaCenters.length > 1) {
+        // Post phase pauses and lets the user choose a single nova
         selectionPending = true;
         stop();
         drawGrid();
@@ -934,12 +941,6 @@ function triggerInfoNova() {
             }
         };
         canvas.addEventListener('click', handler);
-        return;
-    }
-
-    if (genesisPhase === 'post' && latestNovaCenters.length > 1) {
-        // In post phase multiple novas should trigger automatically
-        performNovaSequence();
         return;
     }
 

--- a/tests/postPhaseAuto.test.js
+++ b/tests/postPhaseAuto.test.js
@@ -11,6 +11,7 @@ beforeEach(async () => {
         <input id="pulseLength" value="2" />
         <div id="novaOverlay"></div>
         <div id="novaInfoContainer"></div>
+        <input id="zoomSlider" value="10" />
     `;
     mod = await import('../public/app.js');
     triggerInfoNova = mod.triggerInfoNova;
@@ -35,9 +36,17 @@ beforeEach(async () => {
     prevGrid[7][7] = 1;
 });
 
-test('triggerInfoNova automatically seeds all novas in post phase', () => {
+test('triggerInfoNova waits for manual selection in post phase', () => {
     triggerInfoNova();
-    expect(global.start).toHaveBeenCalled();
+    // start should not fire until a nova center is chosen
+    expect(global.start).not.toHaveBeenCalled();
     const boxes = document.querySelectorAll('.novaInfoBox');
     expect(boxes.length).toBe(2);
+    const canvas = document.getElementById('grid');
+    canvas.getBoundingClientRect = () => ({ left: 0, top: 0, width: 80, height: 80 });
+    global.cellSize = 10;
+    global.offsetX = 0;
+    global.offsetY = 0;
+    canvas.dispatchEvent(new MouseEvent('click', { clientX: 5, clientY: 5 }));
+    expect(global.start).toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- update README to explain new Genesis Phase behavior
- invert nova selection logic in `triggerInfoNova`
- adjust post phase test to cover manual selection

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed49015c48330b2da0411b90e4b17