### PR TITLE
Refactor updateCellState for emergent BPT logic

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -379,7 +379,8 @@ function update() {
     }
     const frameDuration = now - lastFrameTime;
     lastFrameTime = now;
-    const foldThreshold = parseInt(foldSlider.value);
+    const collapseLimit = parseInt(foldSlider.value);
+    const harmonyRatio = neighborThreshold / 8;
     if (reverse) {
         const prev = history.pop();
         if (prev) {
@@ -402,7 +403,17 @@ function update() {
             const foldRow = [];
             for (let c = 0; c < cols; c++) {
                 const n = getNeighborsSum(grid, r, c);
-                const { val, folded } = updateCellState({ grid, residueGrid, lastStateGrid, flickerCountGrid, neighborThreshold, r, c, n, foldThreshold });
+                const { val, folded } = updateCellState({
+                    grid,
+                    residueGrid,
+                    lastStateGrid,
+                    flickerCountGrid,
+                    r,
+                    c,
+                    n,
+                    harmonyRatio,
+                    collapseLimit
+                });
 
                 if (debugOverlay) {
                     console.log('threshold', neighborThreshold, 'row', r, 'col', c, 'n', n, 'val', val);

--- a/public/logic.js
+++ b/public/logic.js
@@ -16,39 +16,39 @@ export function getNeighborsSum(grid, r, c) {
 }
 
 export function updateCellState(params) {
-    const { grid, residueGrid, lastStateGrid, flickerCountGrid, neighborThreshold, r, c, n, foldThreshold } = params;
-    let val = grid[r][c];
-    let folded = false;
+    const {
+        grid,
+        residueGrid,
+        lastStateGrid,
+        flickerCountGrid,
+        r,
+        c,
+        n,
+        harmonyRatio,
+        collapseLimit
+    } = params;
 
-    if (foldThreshold > 0 && flickerCountGrid[r][c] >= foldThreshold) {
+    // Base value derived from neighbor harmony
+    let val = (n / 8) >= harmonyRatio ? 1 : 0;
+
+    // Residue nudges the cell on but never overrides completely
+    if (residueGrid[r][c] > 0) {
+        val = Math.max(val, 1);
+        residueGrid[r][c]--;
+    }
+
+    // Track instability via flicker counts
+    if (val !== lastStateGrid[r][c]) {
+        flickerCountGrid[r][c] += 1;
+    } else if (flickerCountGrid[r][c] > 0) {
+        flickerCountGrid[r][c] -= 1;
+    }
+
+    let folded = false;
+    if (collapseLimit > 0 && flickerCountGrid[r][c] > collapseLimit) {
         val = 0;
         folded = true;
         flickerCountGrid[r][c] = 0;
-    } else {
-        if (neighborThreshold === 0) {
-            val = grid[r][c] ? 0 : 1;
-        } else {
-            val = n === neighborThreshold ? 1 : 0;
-        }
-
-        if (residueGrid[r][c] > 0) {
-            val = 1;
-            residueGrid[r][c]--;
-        }
-
-        if (foldThreshold > 0 && n > foldThreshold) {
-            val = 0;
-            folded = true;
-            flickerCountGrid[r][c] = 0;
-        }
-
-        if (!folded) {
-            if (val !== lastStateGrid[r][c]) {
-                flickerCountGrid[r][c] += 1;
-            } else {
-                flickerCountGrid[r][c] = 0;
-            }
-        }
     }
 
     lastStateGrid[r][c] = val;

--- a/tests/logic.test.js
+++ b/tests/logic.test.js
@@ -1,8 +1,8 @@
 import { updateCellState } from '../public/logic.js';
 
-test('updateCellState toggles cell based on neighbor count', () => {
+test('updateCellState activates when neighbor harmony satisfied', () => {
     const grid = [
-        [0,1,0],
+        [0,0,0],
         [0,0,0],
         [0,0,0]
     ];
@@ -21,7 +21,46 @@ test('updateCellState toggles cell based on neighbor count', () => {
         [0,0,0],
         [0,0,0]
     ];
-    const params = { grid, residueGrid: residue, lastStateGrid: last, flickerCountGrid: flicker, neighborThreshold: 1, r:0, c:1, n:1, foldThreshold:0 };
+    const params = {
+        grid,
+        residueGrid: residue,
+        lastStateGrid: last,
+        flickerCountGrid: flicker,
+        r: 1,
+        c: 1,
+        n: 4,
+        harmonyRatio: 0.5,
+        collapseLimit: 2
+    };
     const { val } = updateCellState(params);
+    expect(val).toBe(1);
+});
+
+test('updateCellState collapses when flicker exceeds limit', () => {
+    const grid = [
+        [0]
+    ];
+    const residue = [
+        [0]
+    ];
+    const last = [
+        [1]
+    ];
+    const flicker = [
+        [3]
+    ];
+    const params = {
+        grid,
+        residueGrid: residue,
+        lastStateGrid: last,
+        flickerCountGrid: flicker,
+        r: 0,
+        c: 0,
+        n: 0,
+        harmonyRatio: 0,
+        collapseLimit: 2
+    };
+    const { val, folded } = updateCellState(params);
     expect(val).toBe(0);
+    expect(folded).toBe(true);
 });


### PR DESCRIPTION
## Summary
- rework `updateCellState` to use harmony ratio and residue influence
- integrate flicker collapse via a single limit
- adapt app code to provide `harmonyRatio` and `collapseLimit`
- rewrite unit tests for new behavior

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eda0ed81483309910250e34ff39ee