### PR TITLE
Enhance cell flicker logic

### DIFF
--- a/public/logic.js
+++ b/public/logic.js
@@ -38,12 +38,15 @@ export function updateCellState(params) {
     const flickerCount = flickerCountGrid[r][c];
     const cap = getResonanceCap(r, c, grid.length, grid[0].length);
 
-    // Base value derived from neighbor harmony with negative feedback
-    let val = (n / 8 >= harmonyRatio && flickerCount < cap) ? 1 : 0;
+    // Base value derived from neighbor harmony with pulse toggling
+    let val = 0;
+    if (n / 8 >= harmonyRatio && flickerCount < cap) {
+        val = lastStateGrid[r][c] === 0 ? 1 : 0;
+    }
 
-    // Residue nudges the cell on but never overrides completely
+    // Residue nudges the cell toward on without overriding
     if (residueGrid[r][c] > 0) {
-        val = Math.max(val, 1);
+        val = Math.max(val, (residueGrid[r][c] / 5));
         residueGrid[r][c]--;
     }
 
@@ -51,7 +54,7 @@ export function updateCellState(params) {
     if (val !== lastStateGrid[r][c]) {
         flickerCountGrid[r][c] += 1;
     } else if (flickerCountGrid[r][c] > 0) {
-        flickerCountGrid[r][c] -= 1;
+        flickerCountGrid[r][c] *= 0.9;
     }
 
     let folded = false;

--- a/tests/logic.test.js
+++ b/tests/logic.test.js
@@ -97,6 +97,42 @@ test('flicker count increments when state changes', () => {
     expect(val).toBe(1);
     expect(flicker[0][0]).toBe(1);
     ({ val } = updateCellState(params));
+    expect(val).toBe(0);
+    expect(flicker[0][0]).toBeGreaterThan(1);
+});
+
+test('flicker count decays softly when stable', () => {
+    const grid = [
+        [0]
+    ];
+    const residue = [
+        [0]
+    ];
+    const last = [
+        [0]
+    ];
+    const flicker = [
+        [0]
+    ];
+    const params = {
+        grid,
+        residueGrid: residue,
+        lastStateGrid: last,
+        flickerCountGrid: flicker,
+        r: 0,
+        c: 0,
+        n: 8,
+        harmonyRatio: 0.25,
+        collapseLimit: 5
+    };
+    let { val } = updateCellState(params);
     expect(val).toBe(1);
     expect(flicker[0][0]).toBe(1);
+    ({ val } = updateCellState(params));
+    expect(val).toBe(0);
+    expect(flicker[0][0]).toBe(2);
+    params.n = 0;
+    ({ val } = updateCellState(params));
+    expect(val).toBe(0);
+    expect(flicker[0][0]).toBeCloseTo(1.8);
 });


### PR DESCRIPTION
## Summary
- refine `updateCellState` for pulse toggling
- apply soft flicker decay and subtle residue influence
- update tests for new logic and add decay test

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: `eslint` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee21107b48330be6efbac213c11b1