### PR TITLE
Add inverse color residue glow

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -243,6 +243,14 @@ function countCellChanges(prev, curr) {
     return changes;
 }
 
+function invertHexColor(hex) {
+    if (hex.startsWith('#')) hex = hex.slice(1);
+    const r = 255 - parseInt(hex.slice(0, 2), 16);
+    const g = 255 - parseInt(hex.slice(2, 4), 16);
+    const b = 255 - parseInt(hex.slice(4, 6), 16);
+    return { r, g, b };
+}
+
 function drawGrid() {
     ctx.fillStyle = '#000';
     ctx.fillRect(0, 0, canvas.width, canvas.height);
@@ -259,6 +267,10 @@ function drawGrid() {
                 }
             } else if (foldGrid[r][c] === 1) {
                 ctx.fillStyle = '#111';
+            } else if (residueGrid[r][c] > 0) {
+                const { r: rr, g: gg, b: bb } = invertHexColor(colorGrid[r][c]);
+                const alpha = Math.min(1, residueGrid[r][c] / 10);
+                ctx.fillStyle = `rgba(${rr}, ${gg}, ${bb}, ${alpha})`;
             } else if (potentialGrid[r][c] > 0) {
                 const alpha = Math.min(potentialGrid[r][c] / potentialThreshold, 1) * 0.6;
                 ctx.fillStyle = `rgba(255, 255, 100, ${alpha})`;
@@ -1404,4 +1416,4 @@ if (hardResetBtn) {
 
 // Additional hooks for pulse direction and substrate density will be added later.
 
-export { init, triggerInfoNova, latestNovaCenter, latestNovaCenters, genesisMode, genesisPhase, lockGenesisPhase, showNovaInfo, centerOnNova, repositionNovaInfoBoxes };
+export { init, triggerInfoNova, latestNovaCenter, latestNovaCenters, genesisMode, genesisPhase, lockGenesisPhase, showNovaInfo, centerOnNova, repositionNovaInfoBoxes, invertHexColor };

--- a/tests/invertColor.test.js
+++ b/tests/invertColor.test.js
@@ -1,0 +1,8 @@
+import { invertHexColor } from '../public/app.js';
+
+test('invertHexColor returns RGB inversion', () => {
+    const { r, g, b } = invertHexColor('#123456');
+    expect(r).toBe(0xED);
+    expect(g).toBe(0xCA);
+    expect(b).toBe(0xA9);
+});


### PR DESCRIPTION
## Summary
- introduce `invertHexColor` utility for hex color inversion
- use residue grid values to draw an inverse-color glow around decaying cells
- export the helper for testing and add unit test

## Testing
- `npm run lint`
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee9cea49883308cfc03aa1e0012d6