### PR TITLE
Implement inverse residue glow

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -244,10 +244,10 @@ function countCellChanges(prev, curr) {
 }
 
 function invertHexColor(hex) {
-    if (hex.startsWith('#')) hex = hex.slice(1);
-    const r = 255 - parseInt(hex.slice(0, 2), 16);
-    const g = 255 - parseInt(hex.slice(2, 4), 16);
-    const b = 255 - parseInt(hex.slice(4, 6), 16);
+    if (hex[0] === "#") hex = hex.slice(1);
+    const r = 255 - parseInt(hex.substring(0, 2), 16);
+    const g = 255 - parseInt(hex.substring(2, 4), 16);
+    const b = 255 - parseInt(hex.substring(4, 6), 16);
     return { r, g, b };
 }
 
@@ -259,17 +259,22 @@ function drawGrid() {
     const drawSize = showGridLines ? Math.max(cellSize - 1, 1) : cellSize;
     for (let r = 0; r < rows; r++) {
         for (let c = 0; c < cols; c++) {
-            if (grid[r][c] === 1) {
+            const cellVal = grid[r][c];
+            const residue = residueGrid[r][c];
+            if (cellVal === 1) {
                 if (running && pulseFlash && flickerCountGrid[r][c] > 0) {
                     ctx.fillStyle = '#000';
                 } else {
                     ctx.fillStyle = colorGrid[r][c];
                 }
+            } else if (cellVal === 0.5) {
+                const { r: rr, g: gg, b: bb } = invertHexColor(colorGrid[r][c]);
+                ctx.fillStyle = `rgba(${rr}, ${gg}, ${bb}, 0.4)`;
             } else if (foldGrid[r][c] === 1) {
                 ctx.fillStyle = '#111';
-            } else if (residueGrid[r][c] > 0) {
+            } else if (residue > 0 && cellVal === 0) {
                 const { r: rr, g: gg, b: bb } = invertHexColor(colorGrid[r][c]);
-                const alpha = Math.min(1, residueGrid[r][c] / 10);
+                const alpha = Math.min(1, residue / 10);
                 ctx.fillStyle = `rgba(${rr}, ${gg}, ${bb}, ${alpha})`;
             } else if (potentialGrid[r][c] > 0) {
                 const alpha = Math.min(potentialGrid[r][c] / potentialThreshold, 1) * 0.6;

--- a/public/logic.js
+++ b/public/logic.js
@@ -47,9 +47,11 @@ export function updateCellState(params) {
         val = lastStateGrid[r][c] === 0 ? 1 : 0;
     }
 
-    // Residue nudges the cell toward on without overriding
+    // Residue nudges the cell toward on or a semi-active glow
     if (residueGrid[r][c] > 0) {
-        val = Math.max(val, (residueGrid[r][c] / 5));
+        const residue = residueGrid[r][c];
+        const residueVal = residue > 3 ? 1 : 0.5;
+        val = Math.max(val, residueVal);
         residueGrid[r][c]--;
     }
 
@@ -83,6 +85,8 @@ export function updateCellState(params) {
         potentialGrid[r][c] = 0;
     }
 
+    // Clamp to valid range
+    val = Math.max(0, Math.min(1, val));
     lastStateGrid[r][c] = val;
     return { val, folded, emergent };
 }

--- a/tests/logic.test.js
+++ b/tests/logic.test.js
@@ -192,3 +192,53 @@ test('potential accumulation sparks cell on', () => {
     expect(res.val).toBe(1);
     expect(potential[0][0]).toBe(0);
 });
+
+test('residue over threshold activates cell fully', () => {
+    const grid = [[0]];
+    const residue = [[4]];
+    const last = [[0]];
+    const flicker = [[0]];
+    const potential = [[0]];
+    const params = {
+        grid,
+        residueGrid: residue,
+        lastStateGrid: last,
+        flickerCountGrid: flicker,
+        potentialGrid: potential,
+        r: 0,
+        c: 0,
+        n: 0,
+        harmonyRatio: 0,
+        collapseLimit: 0,
+        potentialThreshold: 1,
+        decayRate: 1
+    };
+    const res = updateCellState(params);
+    expect(res.val).toBe(1);
+    expect(residue[0][0]).toBe(3);
+});
+
+test('residue low sets semi-active glow', () => {
+    const grid = [[0]];
+    const residue = [[2]];
+    const last = [[0]];
+    const flicker = [[0]];
+    const potential = [[0]];
+    const params = {
+        grid,
+        residueGrid: residue,
+        lastStateGrid: last,
+        flickerCountGrid: flicker,
+        potentialGrid: potential,
+        r: 0,
+        c: 0,
+        n: 0,
+        harmonyRatio: 0,
+        collapseLimit: 0,
+        potentialThreshold: 1,
+        decayRate: 1
+    };
+    const res = updateCellState(params);
+    expect(res.val).toBe(0.5);
+    expect(residue[0][0]).toBe(1);
+});


### PR DESCRIPTION
## Summary
- change invertHexColor implementation to handle `#` check
- improve drawGrid rendering logic for residue cells
- clamp residue effects in updateCellState
- ensure updateCellState output stays within `[0,1]`
- add tests for new residue behaviors

## Testing
- `npm run lint --silent`
- `npm test --silent` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eed9b1dc88330aeed0731026600ee