### PR TITLE
Implement phase-based color gradient

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Pulse-Core is a browser-based sandbox for experimenting with a simple pulse simu
 - **Randomize button** – Fill the entire field with random cells using the current grid size.
 - **Adjustable sliders** – Tune pulse length, fold threshold, zoom level, neighbor count and collapse threshold (in Pulse Units) on the fly.
 - **Tool selection** – Switch between brush, pulse injector and pattern stamper. Right-click cells to erase.
-- **Color picker** – Choose the color used for brush strokes, injected pulses and stamped patterns.
+- **Color picker** – Choose the color used for brush strokes, injected pulses and stamped patterns. Cell rendering now uses a phase-based gradient.
+- **Phase colors** – Hue represents cell phase from red (inactive) to cyan (active) with intermediate tones for residue and flicker.
 - **Reverse stepping** – Walk backward through up to 200 prior pulses.
 - **Pattern saving** – Download the entire grid as a JSON file and reload it later with the upload option.
 - **Optional overlays** – Toggle pulse flash, field tension mapping and grid lines.

--- a/tests/colorPhase.test.js
+++ b/tests/colorPhase.test.js
@@ -1,0 +1,13 @@
+import { getColorFromPhase } from '../public/app.js';
+
+test('phase 0 maps to red', () => {
+    expect(getColorFromPhase(0)).toBe('hsl(0, 100%, 50%)');
+});
+
+test('phase 1 maps to cyan', () => {
+    expect(getColorFromPhase(1)).toBe('hsl(180, 100%, 50%)');
+});
+
+test('phase 0.5 maps to mid hue', () => {
+    expect(getColorFromPhase(0.5)).toBe('hsl(90, 100%, 50%)');
+});


### PR DESCRIPTION
## Summary
- map cell phase to a hue with `getColorFromPhase`
- compute phase from residue, flicker and potential in `drawGrid`
- export the new util and add `MAX_RESIDUE` constant
- document the color gradient in README
- add unit tests for `getColorFromPhase`

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686efe6084988330a88ec353c45ec1c3