### PR TITLE
Add grayscale rendering and optional phase color overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
             <option value="reactor-chamber">Dual Reactor Chamber</option>
         </select>
         <label><input type="checkbox" id="pulseFlash"> Pulse Flash</label>
+        <label><input type="checkbox" id="phaseColorToggle"> Phase Colors</label>
         <label><input type="checkbox" id="gridLinesToggle" checked> Grid Lines</label>
         <label><input type="checkbox" id="centerViewToggle"> Center View</label>
         <div>Frame Duration: <span id="frameDuration">0</span>ms</div>

--- a/tests/colorPhase.test.js
+++ b/tests/colorPhase.test.js
@@ -1,4 +1,4 @@
-import { getColorFromPhase } from '../public/app.js';
+import { getColorFromPhase, getHueFromPhase, getValueFromPhase } from '../public/app.js';
 
 test('phase 0 maps to red', () => {
     expect(getColorFromPhase(0)).toBe('hsl(0, 100%, 50%)');
@@ -10,4 +10,14 @@ test('phase 1 maps to cyan', () => {
 
 test('phase 0.5 maps to mid hue', () => {
     expect(getColorFromPhase(0.5)).toBe('hsl(90, 100%, 50%)');
+});
+
+test('getHueFromPhase mirrors getColorFromPhase', () => {
+    expect(getHueFromPhase(0)).toBe('hsl(0, 100%, 50%)');
+    expect(getHueFromPhase(1)).toBe('hsl(180, 100%, 50%)');
+});
+
+test('getValueFromPhase converts to grayscale', () => {
+    expect(getValueFromPhase(0)).toBe('rgb(0, 0, 0)');
+    expect(getValueFromPhase(1)).toBe('rgb(255, 255, 255)');
 });


### PR DESCRIPTION
## Summary
- support grayscale base with optional phase color overlay
- expose Phase Colors checkbox in `index.html`
- export `getHueFromPhase` and `getValueFromPhase`
- test color helper functions

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f03733778833091d16ba3dd22d59c