### PR TITLE
Add phase color overlay and brush hue support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Pulse-Core is a browser-based sandbox for experimenting with a simple pulse simu
 - **Randomize button** – Fill the entire field with random cells using the current grid size.
 - **Adjustable sliders** – Tune pulse length, fold threshold, zoom level, neighbor count and collapse threshold (in Pulse Units) on the fly.
 - **Tool selection** – Switch between brush, pulse injector and pattern stamper. Right-click cells to erase.
-- **Color picker** – Choose the color used for brush strokes, injected pulses and stamped patterns. Cell rendering now uses a phase-based gradient.
-- **Phase colors** – Hue represents cell phase from red (inactive) to cyan (active) with intermediate tones for residue and flicker.
+- **Color picker** – Choose a hue for brush strokes, injected pulses and stamped patterns.
+- **Phase colors** – Hue represents cell phase from red (inactive) to cyan (active) with intermediate tones for residue and flicker. Use the **Phase Colors** checkbox to toggle the overlay above the grayscale base.
 - **Reverse stepping** – Walk backward through up to 200 prior pulses.
 - **Pattern saving** – Download the entire grid as a JSON file and reload it later with the upload option.
 - **Optional overlays** – Toggle pulse flash, field tension mapping and grid lines.

--- a/tests/colorPhase.test.js
+++ b/tests/colorPhase.test.js
@@ -1,4 +1,4 @@
-import { getColorFromPhase, getHueFromPhase, getValueFromPhase } from '../public/app.js';
+import { getColorFromPhase, getHueFromPhase, getValueFromPhase, getPhaseFromColor } from '../public/app.js';
 
 test('phase 0 maps to red', () => {
     expect(getColorFromPhase(0)).toBe('hsl(0, 100%, 50%)');
@@ -20,4 +20,9 @@ test('getHueFromPhase mirrors getColorFromPhase', () => {
 test('getValueFromPhase converts to grayscale', () => {
     expect(getValueFromPhase(0)).toBe('rgb(0, 0, 0)');
     expect(getValueFromPhase(1)).toBe('rgb(255, 255, 255)');
+});
+
+test('getPhaseFromColor converts RGB hex to phase', () => {
+    expect(getPhaseFromColor('#ff0000')).toBe(0);
+    expect(getPhaseFromColor('#00ffff')).toBe(1);
 });

--- a/tests/datanova.test.js
+++ b/tests/datanova.test.js
@@ -18,7 +18,7 @@ beforeEach(async () => {
     global.rows = 8;
     global.cols = 8;
     global.grid = Array.from({ length: rows }, () => Array(cols).fill(0));
-    global.colorGrid = Array.from({ length: rows }, () => Array(cols).fill('#fff'));
+    global.colorGrid = Array.from({ length: rows }, () => Array(cols).fill(null));
     global.neighborThreshold = 1;
     global.pulseLength = 2;
     global.foldSlider = { value: '0' };

--- a/tests/genesisMode.test.js
+++ b/tests/genesisMode.test.js
@@ -17,7 +17,7 @@ beforeEach(async () => {
     global.rows = 20;
     global.cols = 20;
     global.grid = Array.from({ length: rows }, () => Array(cols).fill(0));
-    global.colorGrid = Array.from({ length: rows }, () => Array(cols).fill('#fff'));
+    global.colorGrid = Array.from({ length: rows }, () => Array(cols).fill(null));
     global.neighborThreshold = 1;
     global.pulseLength = 2;
     global.foldSlider = { value: '0' };

--- a/tests/novaSelection.test.js
+++ b/tests/novaSelection.test.js
@@ -17,7 +17,7 @@ beforeEach(async () => {
     global.rows = 8;
     global.cols = 8;
     global.grid = Array.from({ length: rows }, () => Array(cols).fill(0));
-    global.colorGrid = Array.from({ length: rows }, () => Array(cols).fill('#fff'));
+    global.colorGrid = Array.from({ length: rows }, () => Array(cols).fill(null));
     global.neighborThreshold = 1;
     global.pulseLength = 2;
     global.foldSlider = { value: '0' };

--- a/tests/postPhaseAuto.test.js
+++ b/tests/postPhaseAuto.test.js
@@ -18,7 +18,7 @@ beforeEach(async () => {
     global.rows = 8;
     global.cols = 8;
     global.grid = Array.from({ length: rows }, () => Array(cols).fill(0));
-    global.colorGrid = Array.from({ length: rows }, () => Array(cols).fill('#fff'));
+    global.colorGrid = Array.from({ length: rows }, () => Array(cols).fill(null));
     global.neighborThreshold = 1;
     global.pulseLength = 2;
     global.foldSlider = { value: '0' };


### PR DESCRIPTION
## Summary
- implement getPhaseFromColor helper
- store per-cell painted phase values
- apply hue phase when using the brush tool
- optionally overlay phase hues if `showPhaseColor` is enabled
- document new Phase Colors overlay behaviour
- adjust tests for numeric colorGrid values

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f3b7ebb98833080da761420f9cb96