### PR TITLE
Enable Phase Colors toggle

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -285,6 +285,10 @@ function getPhaseForCell(r, c) {
 }
 
 function drawGrid() {
+    // Ensure the phase color toggle reflects the current checkbox state
+    if (phaseColorToggle) {
+        showPhaseColor = phaseColorToggle.checked;
+    }
     ctx.fillStyle = '#000';
     ctx.fillRect(0, 0, canvas.width, canvas.height);
     ctx.font = `${Math.max(cellSize - 2, 8)}px monospace`;


### PR DESCRIPTION
## Summary
- read the `phaseColorToggle` checkbox on each render so the overlay reflects the latest setting

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f4006eed083309028e5d271fa97e6