### PR TITLE
Implement phase-based color tinting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Pulse-Core is a browser-based sandbox for experimenting with a simple pulse simu
 - **Adjustable sliders** – Tune pulse length, fold threshold, zoom level, neighbor count and collapse threshold (in Pulse Units) on the fly.
 - **Tool selection** – Switch between brush, pulse injector and pattern stamper. Right-click cells to erase.
 - **Color picker** – Choose the color used for brush strokes, injected pulses and stamped patterns. Cell rendering now uses a phase-based gradient.
+- **Tinted colors** – When the Phase Colors toggle is off, each cell is drawn using a tinted version of its assigned color based on phase.
 - **Phase colors** – Hue represents cell phase from red (inactive) to cyan (active) with intermediate tones for residue and flicker.
 - **Reverse stepping** – Walk backward through up to 200 prior pulses.
 - **Pattern saving** – Download the entire grid as a JSON file and reload it later with the upload option.

--- a/public/app.js
+++ b/public/app.js
@@ -257,6 +257,18 @@ function invertHexColor(hex) {
     return { r, g, b };
 }
 
+// Tint a hex color toward black based on a phase value [0,1]
+function tintHexColor(hex, phase) {
+    if (hex[0] === '#') hex = hex.slice(1);
+    const r = parseInt(hex.substring(0, 2), 16);
+    const g = parseInt(hex.substring(2, 4), 16);
+    const b = parseInt(hex.substring(4, 6), 16);
+    const nr = Math.round(r * phase);
+    const ng = Math.round(g * phase);
+    const nb = Math.round(b * phase);
+    return `rgb(${nr}, ${ng}, ${nb})`;
+}
+
 function getHueFromPhase(phase) {
     const hue = phase * 180;
     return `hsl(${hue}, 100%, 50%)`;
@@ -310,7 +322,10 @@ function drawGrid() {
             const phase = getPhaseForCell(r, c);
             const resonanceLevel = getResonanceLevel(phase);
 
-            ctx.fillStyle = getValueFromPhase(phase);
+            const baseColor = showPhaseColor
+                ? getValueFromPhase(phase)
+                : tintHexColor(colorGrid[r][c], phase);
+            ctx.fillStyle = baseColor;
             ctx.fillRect(c * cellSize + offsetX, r * cellSize + offsetY, drawSize, drawSize);
 
             if (showPhaseColor) {
@@ -1541,4 +1556,4 @@ if (hardResetBtn) {
 
 // Additional hooks for pulse direction and substrate density will be added later.
 
-export { init, triggerInfoNova, latestNovaCenter, latestNovaCenters, genesisMode, genesisPhase, lockGenesisPhase, showNovaInfo, centerOnNova, repositionNovaInfoBoxes, invertHexColor, getColorFromPhase, getHueFromPhase, getValueFromPhase, getResonanceLevel };
+export { init, triggerInfoNova, latestNovaCenter, latestNovaCenters, genesisMode, genesisPhase, lockGenesisPhase, showNovaInfo, centerOnNova, repositionNovaInfoBoxes, invertHexColor, tintHexColor, getColorFromPhase, getHueFromPhase, getValueFromPhase, getResonanceLevel };

--- a/tests/colorPhase.test.js
+++ b/tests/colorPhase.test.js
@@ -1,4 +1,4 @@
-import { getColorFromPhase, getHueFromPhase, getValueFromPhase } from '../public/app.js';
+import { getColorFromPhase, getHueFromPhase, getValueFromPhase, tintHexColor } from '../public/app.js';
 
 test('phase 0 maps to red', () => {
     expect(getColorFromPhase(0)).toBe('hsl(0, 100%, 50%)');
@@ -20,4 +20,12 @@ test('getHueFromPhase mirrors getColorFromPhase', () => {
 test('getValueFromPhase converts to grayscale', () => {
     expect(getValueFromPhase(0)).toBe('rgb(0, 0, 0)');
     expect(getValueFromPhase(1)).toBe('rgb(255, 255, 255)');
+});
+
+test('tintHexColor darkens to black at phase 0', () => {
+    expect(tintHexColor('#ff0000', 0)).toBe('rgb(0, 0, 0)');
+});
+
+test('tintHexColor returns original color at phase 1', () => {
+    expect(tintHexColor('#00ff00', 1)).toBe('rgb(0, 255, 0)');
 });


### PR DESCRIPTION
## Summary
- tint custom colors by phase with `tintHexColor`
- use tinted colors when phase coloring is disabled
- export helper for tests
- document tinted color behavior
- verify new helper in tests

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686f43a53f148330af8149a56c519088