### PR TITLE
Add visual and audio phase mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
         </select>
         <label><input type="checkbox" id="pulseFlash"> Pulse Flash</label>
         <label><input type="checkbox" id="phaseColorToggle"> Phase Colors</label>
+        <label><input type="checkbox" id="soundToggle"> Enable Sound</label>
         <label><input type="checkbox" id="gridLinesToggle" checked> Grid Lines</label>
         <label><input type="checkbox" id="centerViewToggle"> Center View</label>
         <div>Frame Duration: <span id="frameDuration">0</span>ms</div>

--- a/public/app.js
+++ b/public/app.js
@@ -7,6 +7,7 @@ const PULSE_UNIT = 2000; // adjust empirically if needed
 const MAX_RESIDUE = 10;
 // Number of harmonic tiers used to bucket phase values
 const harmonicCount = 8;
+const baseFreq = 220;
 // Basic pulse simulation grid
 // Each cell toggles between 0 and 1.
 // Folding logic will hook into update() using the foldSlider value.
@@ -43,6 +44,7 @@ const debugCheckbox = document.getElementById('debugOverlay');
 const fieldTensionDropdown = document.getElementById('fieldTensionMode');
 const pulseFlashCheckbox = document.getElementById('pulseFlash');
 const phaseColorToggle = document.getElementById('phaseColorToggle');
+const soundToggle = document.getElementById('soundToggle');
 const patternLoader = document.getElementById('patternLoader');
 const patternUploadBtn = document.getElementById('patternUploadBtn');
 const patternSaverButton = document.getElementById('patternSaverButton');
@@ -97,6 +99,8 @@ let maxDimension = resolutionSlider ? parseInt(resolutionSlider.value) : 500;
 
 let pulseFlash = true;
 let showPhaseColor = false;
+let enableSound = false;
+let audioCtx = null;
 let lastFrameTime = performance.now();
 let startTime = null;
 let timeElapsed = 0;
@@ -291,6 +295,20 @@ function getResonanceLevel(phase) {
     return Math.min(harmonicCount - 1, Math.floor(phase * harmonicCount));
 }
 
+function playPulseTone(freq, duration = 0.1) {
+    if (!audioCtx) return;
+    const osc = audioCtx.createOscillator();
+    const gain = audioCtx.createGain();
+    osc.type = 'sine';
+    osc.frequency.value = freq;
+    osc.connect(gain);
+    gain.connect(audioCtx.destination);
+    gain.gain.setValueAtTime(0.05, audioCtx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + duration);
+    osc.start();
+    osc.stop(audioCtx.currentTime + duration);
+}
+
 function drawGrid() {
     // Ensure the phase color toggle reflects the current checkbox state
     if (phaseColorToggle) {
@@ -314,15 +332,7 @@ function drawGrid() {
             ctx.fillRect(c * cellSize + offsetX, r * cellSize + offsetY, drawSize, drawSize);
 
             if (showPhaseColor) {
-                const tierHueOffset = resonanceLevel * 30;
-                let overlay = `hsl(${tierHueOffset}, 100%, 60%)`;
-                if (folded === 1) {
-                    overlay = 'hsl(0, 0%, 10%)';
-                }
-                if (running && pulseFlash && flicker > 0 && cellVal === 1) {
-                    overlay = '#000';
-                }
-                ctx.fillStyle = overlay;
+                ctx.fillStyle = getHueFromPhase(phase);
                 ctx.fillRect(c * cellSize + offsetX, r * cellSize + offsetY, drawSize, drawSize);
             }
 
@@ -484,6 +494,7 @@ function update() {
             const emergentRow = [];
             for (let c = 0; c < cols; c++) {
                 const n = getNeighborsSum(grid, r, c);
+                const phase = getPhaseForCell(r, c);
                 const { val, folded, emergent } = updateCellState({
                     grid,
                     residueGrid,
@@ -506,6 +517,10 @@ function update() {
                 row.push(val);
                 foldRow.push(folded ? 1 : 0);
                 emergentRow.push(emergent ? 1 : 0);
+                if (enableSound && emergent) {
+                    const freq = 220 + phase * 880;
+                    playPulseTone(freq);
+                }
             }
             next.push(row);
             nextFold.push(foldRow);
@@ -1242,6 +1257,10 @@ function init() {
     }
     pulseFlash = pulseFlashCheckbox ? pulseFlashCheckbox.checked : true;
     showPhaseColor = phaseColorToggle ? phaseColorToggle.checked : false;
+    enableSound = soundToggle ? soundToggle.checked : false;
+    if (enableSound && !audioCtx) {
+        audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    }
     showGridLines = gridLinesToggle ? gridLinesToggle.checked : true;
     drawGrid();
     unlockGenesisPhase();
@@ -1370,6 +1389,15 @@ if (phaseColorToggle) {
     phaseColorToggle.addEventListener('change', () => {
         showPhaseColor = phaseColorToggle.checked;
         drawGrid();
+    });
+}
+
+if (soundToggle) {
+    soundToggle.addEventListener('change', () => {
+        enableSound = soundToggle.checked;
+        if (enableSound && !audioCtx) {
+            audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+        }
     });
 }
 


### PR DESCRIPTION
## Summary
- overlay optional hue with `getHueFromPhase` when phase color mode is active
- add base audio tone playback and sound toggle in the UI
- hook tone playback to emergent cells during updates

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f43c689ec8330be4387b715a6d3f1