### PR TITLE
Improve grid line visibility

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -326,7 +326,10 @@ function drawGrid() {
     if (phaseColorToggle) {
         showPhaseColor = phaseColorToggle.checked;
     }
-    ctx.fillStyle = '#000';
+    // When grid lines are shown, fill the canvas with a light gray background so
+    // the 1px gaps between cells appear as visible grid lines. Otherwise use a
+    // solid black background.
+    ctx.fillStyle = showGridLines ? '#444' : '#000';
     ctx.fillRect(0, 0, canvas.width, canvas.height);
     ctx.font = `${Math.max(cellSize - 2, 8)}px monospace`;
     ctx.textBaseline = 'top';


### PR DESCRIPTION
## Summary
- show grid lines by filling the canvas with a light gray color when enabled

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f4d51abf0833091ece57255f4d58f