### PR TITLE
Add grayscale phase mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Pulse-Core is a browser-based sandbox for experimenting with a simple pulse simu
 - **Tool selection** – Switch between brush, pulse injector and pattern stamper. Right-click cells to erase.
 - **Color picker** – Choose the color used for brush strokes, injected pulses and stamped patterns. Cell rendering now uses a phase-based gradient.
 - **Tinted colors** – When the Phase Colors toggle is off, each cell is drawn using a tinted version of its assigned color based on phase.
-- **Phase colors** – Hue represents cell phase from red (inactive) to cyan (active) with intermediate tones for residue and flicker.
+- **Phase colors** – Hue represents cell phase from red (inactive) to cyan (active) with intermediate tones for residue and flicker. Use the Phase Mode dropdown to switch between color and grayscale.
 - **Reverse stepping** – Walk backward through up to 200 prior pulses.
 - **Pattern saving** – Download the entire grid as a JSON file and reload it later with the upload option.
 - **Optional overlays** – Toggle field tension mapping and grid lines.

--- a/index.html
+++ b/index.html
@@ -62,6 +62,13 @@
             <option value="reactor-chamber">Dual Reactor Chamber</option>
         </select>
         <label><input type="checkbox" id="phaseColorToggle"> Phase Colors</label>
+        <div id="phaseModeControls" style="margin-top: 5px;">
+            <label for="phaseMode">Phase Mode:</label>
+            <select id="phaseMode">
+                <option value="color">Color</option>
+                <option value="grayscale">Grayscale</option>
+            </select>
+        </div>
         <label><input type="checkbox" id="soundToggle"> Enable Sound</label>
         <label><input type="checkbox" id="gridLinesToggle" checked> Grid Lines</label>
         <label><input type="checkbox" id="centerViewToggle"> Center View</label>

--- a/public/app.js
+++ b/public/app.js
@@ -95,6 +95,7 @@ let offsetY = 0;
 let maxDimension = resolutionSlider ? parseInt(resolutionSlider.value) : 500;
 
 let showPhaseColor = false;
+let phaseMode = 'color';
 let enableSound = false;
 let audioCtx = null;
 let lastFrameTime = performance.now();
@@ -274,6 +275,15 @@ function getHueFromPhase(phase) {
     return `hsl(${hue}, 100%, 50%)`;
 }
 
+function getPhaseColor(phase) {
+    if (phaseMode === 'grayscale') {
+        const brightness = Math.floor(Math.max(0, Math.min(1, phase)) * 255);
+        return `rgb(${brightness}, ${brightness}, ${brightness})`;
+    }
+    const hue = phase * 180;
+    return `hsl(${hue}, 100%, 50%)`;
+}
+
 function getValueFromPhase(phase) {
     const brightness = Math.floor(phase * 255);
     return `rgb(${brightness}, ${brightness}, ${brightness})`;
@@ -346,7 +356,7 @@ function drawGrid() {
             ctx.fillRect(c * cellSize + offsetX, r * cellSize + offsetY, drawSize, drawSize);
 
             if (showPhaseColor) {
-                ctx.fillStyle = getHueFromPhase(phase);
+                ctx.fillStyle = getPhaseColor(phase);
                 ctx.fillRect(c * cellSize + offsetX, r * cellSize + offsetY, drawSize, drawSize);
             }
 
@@ -1386,6 +1396,13 @@ if (phaseColorToggle) {
     });
 }
 
+const phaseModeSelect = document.getElementById('phaseMode');
+if (phaseModeSelect) {
+    phaseModeSelect.addEventListener('change', (e) => {
+        phaseMode = e.target.value;
+    });
+}
+
 if (soundToggle) {
     soundToggle.addEventListener('change', () => {
         enableSound = soundToggle.checked;
@@ -1563,4 +1580,4 @@ if (hardResetBtn) {
 
 // Additional hooks for pulse direction and substrate density will be added later.
 
-export { init, triggerInfoNova, latestNovaCenter, latestNovaCenters, genesisMode, genesisPhase, lockGenesisPhase, showNovaInfo, centerOnNova, repositionNovaInfoBoxes, invertHexColor, tintHexColor, getColorFromPhase, getHueFromPhase, getValueFromPhase, getResonanceLevel };
+export { init, triggerInfoNova, latestNovaCenter, latestNovaCenters, genesisMode, genesisPhase, lockGenesisPhase, showNovaInfo, centerOnNova, repositionNovaInfoBoxes, invertHexColor, tintHexColor, getColorFromPhase, getHueFromPhase, getPhaseColor, getValueFromPhase, getResonanceLevel, phaseMode };

--- a/tests/colorPhase.test.js
+++ b/tests/colorPhase.test.js
@@ -1,4 +1,4 @@
-import { getColorFromPhase, getHueFromPhase, getValueFromPhase, tintHexColor } from '../public/app.js';
+import { getColorFromPhase, getHueFromPhase, getValueFromPhase, tintHexColor, getPhaseColor } from '../public/app.js';
 
 test('phase 0 maps to red', () => {
     expect(getColorFromPhase(0)).toBe('hsl(0, 100%, 50%)');
@@ -28,4 +28,8 @@ test('tintHexColor darkens to black at phase 0', () => {
 
 test('tintHexColor returns original color at phase 1', () => {
     expect(tintHexColor('#00ff00', 1)).toBe('rgb(0, 255, 0)');
+});
+
+test('getPhaseColor returns hue in color mode', () => {
+    expect(getPhaseColor(0)).toBe('hsl(0, 100%, 50%)');
 });


### PR DESCRIPTION
## Summary
- add Phase Mode selector in UI
- support grayscale color mode with `getPhaseColor`
- export phase mode utilities
- cover `getPhaseColor` with basic test

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f532e5f08833087b4a77f784e283d