### PR TITLE
Remove duplicate counters from menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,10 +52,6 @@
         <div class="section">
         <h4 class="sectionHeader">🔧 Logic Settings</h4>
         <div class="sectionContent">
-        <div>Frame Duration: <span id="frameDuration">0</span>ms</div>
-        <div>Complexity: <span id="frameComplexity">0</span></div>
-        <div>Pulse Energy: <span id="pulseEnergy">0</span></div>
-        <div id="tensionDisplay">Tension: <span id="tensionValue">0</span></div>
         <label>Collapse Threshold (Pulse Units) <span title="Total pulse energy that collapses the grid.">ℹ️</span>: <input type="number" id="collapseThreshold" value="1" step="0.001"></label>
         <label>Fold Threshold <span title="Number of flickers needed to trigger a collapse.">ℹ️</span>:
             <span id="foldValue">2</span>


### PR DESCRIPTION
## Summary
- drop counter display from the right-hand menu

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870b9aac5048330bb39d5eceb596550