### PR TITLE
Remove db_config from repo and add template

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ npm test
 
 `npm test` runs the Jest suite which validates multi-nova logic, genesis modes and other utilities.
 
+### Database Configuration
+
+Nova event logging requires a `db_config.php` file with your database connection details. Start by copying the provided template and then edit it for your environment:
+
+```sh
+cp db_config.sample.php db_config.php
+# update db_config.php with your credentials
+```
+
+The generated `db_config.php` is ignored by Git so it won't be included in commits.
+
 The project is released under the MIT License (see `LICENSE`).
 
 ---

--- a/db_config.sample.php
+++ b/db_config.sample.php
@@ -1,8 +1,8 @@
 <?php
 $DB_HOST = 'localhost';
-$DB_NAME = 'pulsecore';
-$DB_USER = 'nova_logger';
-$DB_PASS = 'YourSecurePassword';
+$DB_NAME = 'YOUR_DB_NAME';
+$DB_USER = 'YOUR_DB_USER';
+$DB_PASS = 'YOUR_DB_PASSWORD';
 
 try {
     $pdo = new PDO("mysql:host=$DB_HOST;dbname=$DB_NAME;charset=utf8mb4", $DB_USER, $DB_PASS);


### PR DESCRIPTION
## Summary
- keep db_config.php locally only and provide `db_config.sample.php`
- document how to create `db_config.php` from the template

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870bc993e5083308fac6ddf7a3e78ec