### PR TITLE
Set new default color

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
                 <option value="stamper">Pattern Stamper</option>
             </select>
         </label>
-        <label>Color: <input type="color" id="colorPicker" value="#ff6ec7"></label>
+        <label>Color: <input type="color" id="colorPicker" value="#ff009d"></label>
         <label id="patternLabel">Pattern:
             <select id="patternSelect"></select>
         </label>


### PR DESCRIPTION
## Summary
- update color picker default value to `#ff009d`

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870c7784d9c83308f8c6f9a4037115b