### PR TITLE
Add nova logging fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ cp db_config.sample.php db_config.php
 # update db_config.php with your credentials
 ```
 
+If upgrading from an older installation, add the newest columns to your
+`nova_events` table:
+
+```sql
+ALTER TABLE nova_events
+ADD fold_threshold INT,
+ADD potential_threshold FLOAT,
+ADD potential_decay FLOAT,
+ADD phase_mode VARCHAR(50),
+ADD field_mapping VARCHAR(50);
+```
+
 The generated `db_config.php` is ignored by Git so it won't be included in commits.
 
 The project is released under the MIT License (see `LICENSE`).

--- a/nova-data.php
+++ b/nova-data.php
@@ -18,7 +18,8 @@ try {
     $stmt = $pdo->prepare(
         "SELECT timestamp, user_agent, genesis_mode, frame_duration, complexity,
                 pulse_energy, tension, center_row, center_col, pulse_length,
-                neighbor_threshold, collapse_threshold
+                neighbor_threshold, collapse_threshold, fold_threshold,
+                potential_threshold, potential_decay, phase_mode, field_mapping
          FROM nova_events
          ORDER BY timestamp DESC
          LIMIT 100"
@@ -37,6 +38,11 @@ try {
         echo ' Pulse Length: ' . (int)$row['pulse_length']
             . ' | Neighbor Threshold: ' . (int)$row['neighbor_threshold']
             . ' | Collapse Threshold: ' . (float)$row['collapse_threshold'] . "\n";
+        echo ' Fold Threshold: ' . (int)$row['fold_threshold']
+            . ' | Potential Threshold: ' . (float)$row['potential_threshold']
+            . ' | Potential Decay: ' . (float)$row['potential_decay'] . "\n";
+        echo ' Phase Mode: ' . htmlspecialchars($row['phase_mode'])
+            . ' | Field Mapping: ' . htmlspecialchars($row['field_mapping']) . "\n";
         echo str_repeat('-', 40) . "\n";
     }
 } catch (Exception $e) {

--- a/nova.php
+++ b/nova.php
@@ -30,7 +30,12 @@ $requiredFields = [
     'genesis_mode',
     'pulse_length',
     'neighbor_threshold',
-    'collapse_threshold'
+    'collapse_threshold',
+    'fold_threshold',
+    'potential_threshold',
+    'potential_decay',
+    'phase_mode',
+    'field_mapping'
 ];
 
 foreach ($requiredFields as $field) {
@@ -64,14 +69,20 @@ try {
         genesis_mode VARCHAR(32),
         pulse_length INT,
         neighbor_threshold INT,
-        collapse_threshold FLOAT
+        collapse_threshold FLOAT,
+        fold_threshold INT,
+        potential_threshold FLOAT,
+        potential_decay FLOAT,
+        phase_mode VARCHAR(50),
+        field_mapping VARCHAR(50)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 
     $stmt = $pdo->prepare("INSERT INTO nova_events (
         timestamp, time_of_day, user_agent, frame_duration, complexity, pulse_energy,
         tension, center_row, center_col, genesis_mode, pulse_length,
-        neighbor_threshold, collapse_threshold
-    ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)");
+        neighbor_threshold, collapse_threshold, fold_threshold,
+        potential_threshold, potential_decay, phase_mode, field_mapping
+    ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)");
 
     $dt = new DateTime($data['timestamp']);
     $dt->setTimezone(new DateTimeZone('UTC'));
@@ -97,7 +108,12 @@ try {
             $data['genesis_mode'],
             (int)$data['pulse_length'],
             (int)$data['neighbor_threshold'],
-            (float)$data['collapse_threshold']
+            (float)$data['collapse_threshold'],
+            (int)$data['fold_threshold'],
+            (float)$data['potential_threshold'],
+            (float)$data['potential_decay'],
+            $data['phase_mode'],
+            $data['field_mapping']
         ]);
         $inserted++;
     }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "scripts": {
     "lint": "eslint public/*.js",
+    "pretest": "npm install",
     "test": "jest"
   },
   "devDependencies": {

--- a/public/app.js
+++ b/public/app.js
@@ -272,7 +272,12 @@ function sendNovaToServer(centers) {
         genesis_mode: genesisSelect ? genesisSelect.value : '',
         pulse_length: parseInt(pulseLengthInput.value, 10) || 0,
         neighbor_threshold: parseInt(neighborSlider.value, 10) || 0,
-        collapse_threshold: parseFloat(collapseThresholdInput.value || '0') * PULSE_UNIT
+        collapse_threshold: parseFloat(collapseThresholdInput.value || '0') * PULSE_UNIT,
+        fold_threshold: parseInt(foldSlider.value, 10) || 0,
+        potential_threshold: potentialThreshold,
+        potential_decay: decayRate,
+        phase_mode: phaseMode,
+        field_mapping: fieldTensionMode
     };
 
     fetch('nova.php', {


### PR DESCRIPTION
## Summary
- log UI settings for nova events
- handle new columns in nova PHP endpoints
- display the new data in the nova log viewer
- document schema migration
- install dependencies before tests

## Testing
- `npm run lint`
- `npm test` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6870ca6af6cc8330b3433eb33c743ed4