### PR TITLE
Implement nova event hash and log display updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ ADD fold_threshold INT,
 ADD potential_threshold FLOAT,
 ADD potential_decay FLOAT,
 ADD phase_mode VARCHAR(50),
-ADD field_mapping VARCHAR(50);
+ADD field_mapping VARCHAR(50),
+ADD nova_hash VARCHAR(16);
 ```
 
 The generated `db_config.php` is ignored by Git so it won't be included in commits.

--- a/nova-data.php
+++ b/nova-data.php
@@ -19,17 +19,29 @@ try {
         "SELECT timestamp, user_agent, genesis_mode, frame_duration, complexity,
                 pulse_energy, tension, center_row, center_col, pulse_length,
                 neighbor_threshold, collapse_threshold, fold_threshold,
-                potential_threshold, potential_decay, phase_mode, field_mapping
+                potential_threshold, potential_decay, phase_mode, field_mapping,
+                nova_hash
          FROM nova_events
          ORDER BY timestamp DESC
          LIMIT 100"
     );
     $stmt->execute();
 
+    $idx = 1;
+    function showField($val) {
+        if ($val === null || $val === '' || $val == 0) {
+            return 'Missing';
+        }
+        return htmlspecialchars($val);
+    }
+
     while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-        echo htmlspecialchars($row['timestamp']) . "\n";
-        echo ' UA: ' . htmlspecialchars($row['user_agent']) . "\n";
-        echo ' Genesis Mode: ' . htmlspecialchars($row['genesis_mode']) . "\n";
+        printf("%03d - %s \xF0\x9F\x94\x91 Nova Hash: %s\n",
+            $idx,
+            htmlspecialchars($row['timestamp']),
+            showField($row['nova_hash']));
+        echo ' UA: ' . showField($row['user_agent']) . "\n";
+        echo ' Genesis Mode: ' . showField($row['genesis_mode']) . "\n";
         echo ' Frame Duration: ' . (int)$row['frame_duration'] . ' ms'
             . ' | Complexity: ' . (int)$row['complexity']
             . ' | Energy: ' . (float)$row['pulse_energy']
@@ -37,13 +49,14 @@ try {
         echo ' Center: (' . (int)$row['center_row'] . ', ' . (int)$row['center_col'] . ")\n";
         echo ' Pulse Length: ' . (int)$row['pulse_length']
             . ' | Neighbor Threshold: ' . (int)$row['neighbor_threshold']
-            . ' | Collapse Threshold: ' . (float)$row['collapse_threshold'] . "\n";
-        echo ' Fold Threshold: ' . (int)$row['fold_threshold']
-            . ' | Potential Threshold: ' . (float)$row['potential_threshold']
-            . ' | Potential Decay: ' . (float)$row['potential_decay'] . "\n";
-        echo ' Phase Mode: ' . htmlspecialchars($row['phase_mode'])
-            . ' | Field Mapping: ' . htmlspecialchars($row['field_mapping']) . "\n";
+            . ' | Collapse Threshold: ' . showField($row['collapse_threshold']) . "\n";
+        echo ' Fold Threshold: ' . showField($row['fold_threshold'])
+            . ' | Potential Threshold: ' . showField($row['potential_threshold'])
+            . ' | Potential Decay: ' . showField($row['potential_decay']) . "\n";
+        echo ' Phase Mode: ' . showField($row['phase_mode'])
+            . ' | Field Mapping: ' . showField($row['field_mapping']) . "\n";
         echo str_repeat('-', 40) . "\n";
+        $idx++;
     }
 } catch (Exception $e) {
     echo "Error retrieving nova data.";

--- a/nova.php
+++ b/nova.php
@@ -74,15 +74,17 @@ try {
         potential_threshold FLOAT,
         potential_decay FLOAT,
         phase_mode VARCHAR(50),
-        field_mapping VARCHAR(50)
+        field_mapping VARCHAR(50),
+        nova_hash VARCHAR(16)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 
     $stmt = $pdo->prepare("INSERT INTO nova_events (
         timestamp, time_of_day, user_agent, frame_duration, complexity, pulse_energy,
         tension, center_row, center_col, genesis_mode, pulse_length,
         neighbor_threshold, collapse_threshold, fold_threshold,
-        potential_threshold, potential_decay, phase_mode, field_mapping
-    ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)");
+        potential_threshold, potential_decay, phase_mode, field_mapping,
+        nova_hash
+    ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)");
 
     $dt = new DateTime($data['timestamp']);
     $dt->setTimezone(new DateTimeZone('UTC'));
@@ -95,6 +97,10 @@ try {
             continue;
         }
         [$row, $col] = $center;
+        $eventData = $data;
+        $eventData['center_row'] = (int)$row;
+        $eventData['center_col'] = (int)$col;
+        $novaHash = substr(md5(json_encode($eventData)), 0, 8);
         $stmt->execute([
             $timestamp,
             $timeOfDay,
@@ -113,7 +119,8 @@ try {
             (float)$data['potential_threshold'],
             (float)$data['potential_decay'],
             $data['phase_mode'],
-            $data['field_mapping']
+            $data['field_mapping'],
+            $novaHash
         ]);
         $inserted++;
     }

--- a/public/app.js
+++ b/public/app.js
@@ -272,10 +272,10 @@ function sendNovaToServer(centers) {
         genesis_mode: genesisSelect ? genesisSelect.value : '',
         pulse_length: parseInt(pulseLengthInput.value, 10) || 0,
         neighbor_threshold: parseInt(neighborSlider.value, 10) || 0,
-        collapse_threshold: parseFloat(collapseThresholdInput.value || '0') * PULSE_UNIT,
-        fold_threshold: parseInt(foldSlider.value, 10) || 0,
-        potential_threshold: potentialThreshold,
-        potential_decay: decayRate,
+        collapse_threshold: parseInt(collapseThresholdInput.value, 10),
+        fold_threshold: parseInt(foldSlider.value, 10),
+        potential_threshold: parseFloat(potentialThreshold),
+        potential_decay: parseFloat(decayRate),
         phase_mode: phaseMode,
         field_mapping: fieldTensionMode
     };


### PR DESCRIPTION
## Summary
- include additional nova parameters when sending logs
- store a nova_hash for each event and add to the nova_events schema
- fix collapse threshold mismatch when logging
- display nova hash and sequential numbering in nova-data.php
- document new schema changes in README

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint)*

------
https://chatgpt.com/codex/tasks/task_e_6870d213bccc8330873bacf6ebb3783a