### PR TITLE
Remove frame_duration references

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ ADD field_mapping VARCHAR(50),
 ADD nova_hash VARCHAR(16);
 ```
 
+To remove the deprecated `frame_duration` column, run:
+
+```sql
+ALTER TABLE nova_events DROP COLUMN frame_duration;
+```
+
 The generated `db_config.php` is ignored by Git so it won't be included in commits.
 
 The project is released under the MIT License (see `LICENSE`).

--- a/nova-data.php
+++ b/nova-data.php
@@ -21,7 +21,7 @@ try {
     $limit = 100;
     $offset = ($page - 1) * $limit;
     $stmt = $pdo->prepare(
-        "SELECT id, timestamp, user_agent, genesis_mode, frame_duration, complexity,
+        "SELECT id, timestamp, user_agent, genesis_mode, complexity,
                 pulse_energy, tension, center_row, center_col, pulse_length,
                 neighbor_threshold, collapse_threshold, fold_threshold,
                 potential_threshold, potential_decay, phase_mode, field_mapping,
@@ -55,8 +55,7 @@ try {
             showField($row['nova_hash']));
         echo ' UA: ' . showField($row['user_agent']) . "\n";
         echo ' Genesis Mode: ' . showField($row['genesis_mode']) . "\n";
-        echo ' Frame Duration: ' . (int)$row['frame_duration'] . ' ms'
-            . ' | Complexity: ' . (int)$row['complexity']
+        echo ' Complexity: ' . (int)$row['complexity']
             . ' | Energy: ' . (float)$row['pulse_energy']
             . ' | Tension: ' . (int)$row['tension'] . "\n";
         echo ' Center: (' . (int)$row['center_row'] . ', ' . (int)$row['center_col'] . ")\n";
@@ -98,8 +97,7 @@ try {
         text += String(nextIndex).padStart(3, '0') + ' - ' + row.timestamp + ' \uD83D\uDD11 Nova Hash: ' + showField(row.nova_hash) + '\n';
         text += ' UA: ' + showField(row.user_agent) + '\n';
         text += ' Genesis Mode: ' + showField(row.genesis_mode) + '\n';
-        text += ' Frame Duration: ' + parseInt(row.frame_duration) + ' ms' +
-            ' | Complexity: ' + parseInt(row.complexity) +
+        text += ' Complexity: ' + parseInt(row.complexity) +
             ' | Energy: ' + parseFloat(row.pulse_energy) +
             ' | Tension: ' + parseInt(row.tension) + '\n';
         text += ' Center: (' + parseInt(row.center_row) + ', ' + parseInt(row.center_col) + ')\n';

--- a/nova-events.php
+++ b/nova-events.php
@@ -7,7 +7,7 @@ $after = isset($_GET['after']) ? intval($_GET['after']) : 0;
 
 try {
     $stmt = $pdo->prepare(
-        "SELECT id, timestamp, user_agent, genesis_mode, frame_duration, complexity,
+        "SELECT id, timestamp, user_agent, genesis_mode, complexity,
                 pulse_energy, tension, center_row, center_col, pulse_length,
                 neighbor_threshold, collapse_threshold, fold_threshold,
                 potential_threshold, potential_decay, phase_mode, field_mapping,

--- a/nova.php
+++ b/nova.php
@@ -22,7 +22,6 @@ if (!is_array($data)) {
 $requiredFields = [
     'timestamp',
     'user_agent',
-    'frame_duration',
     'complexity',
     'pulse_energy',
     'tension',
@@ -60,7 +59,6 @@ try {
         timestamp DATETIME,
         time_of_day VARCHAR(8),
         user_agent TEXT,
-        frame_duration INT,
         complexity INT,
         pulse_energy FLOAT,
         tension INT,
@@ -79,12 +77,12 @@ try {
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 
     $stmt = $pdo->prepare("INSERT INTO nova_events (
-        timestamp, time_of_day, user_agent, frame_duration, complexity, pulse_energy,
+        timestamp, time_of_day, user_agent, complexity, pulse_energy,
         tension, center_row, center_col, genesis_mode, pulse_length,
         neighbor_threshold, collapse_threshold, fold_threshold,
         potential_threshold, potential_decay, phase_mode, field_mapping,
         nova_hash
-    ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)");
+    ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)");
 
     $dt = new DateTime($data['timestamp']);
     $dt->setTimezone(new DateTimeZone('UTC'));
@@ -105,7 +103,6 @@ try {
             $timestamp,
             $timeOfDay,
             $data['user_agent'],
-            (int)$data['frame_duration'],
             (int)$data['complexity'],
             (float)$data['pulse_energy'],
             (int)$data['tension'],

--- a/public/app.js
+++ b/public/app.js
@@ -265,7 +265,6 @@ function sendNovaToServer(centers) {
     const data = {
         timestamp: new Date().toISOString(),
         user_agent: navigator.userAgent,
-        frame_duration: parseInt(frameDurationSpan.textContent, 10) || 0,
         complexity: parseInt(frameComplexitySpan.textContent, 10) || 0,
         pulse_energy: parseFloat(pulseEnergySpan.textContent) || 0,
         tension: parseInt(tensionValueSpan.textContent, 10) || 0,


### PR DESCRIPTION
## Summary
- drop frame_duration from nova logging backend
- stop sending frame_duration from the client
- remove frame_duration display from nova logs
- document dropping the column in README

## Testing
- `npm run lint`
- `npm test` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_6870daf7cb408330b44bc5cbbf133fb3