### PR TITLE
Adjust collapse threshold calculation

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -88,7 +88,7 @@ let neighborThreshold = parseInt(neighborSlider.value);
 let debugOverlay = false;
 let fieldTensionMode = 'none';
 let activeCellCount = 0;
-let collapseThreshold = parseFloat(collapseThresholdInput.value || '1') * 1000 * PULSE_UNIT;
+let collapseThreshold = parseFloat(collapseThresholdInput.value || '1') * PULSE_UNIT;
 let potentialThreshold = parseFloat(potentialThresholdInput ? potentialThresholdInput.value : '0.5');
 let decayRate = parseFloat(potentialDecayInput ? potentialDecayInput.value : '0.95');
 let showGridLines = true;
@@ -1413,7 +1413,7 @@ pulseLengthInput.addEventListener('input', () => {
 });
 
 collapseThresholdInput.addEventListener('input', () => {
-    collapseThreshold = parseFloat(collapseThresholdInput.value || '1') * 1000 * PULSE_UNIT;
+    collapseThreshold = parseFloat(collapseThresholdInput.value || '1') * PULSE_UNIT;
 });
 
 frameRateSlider.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- fix collapse threshold calculation to remove extra `1000` multiplier

## Testing
- `npm test` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6870ee3bf5ac8330822b41c2c4a35d44