### PR TITLE
Fix nova data caching

### DIFF
--- a/nova-data.php
+++ b/nova-data.php
@@ -2,6 +2,8 @@
 require_once 'db_config.php';
 
 header('Content-Type: text/html; charset=utf-8');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+header('Pragma: no-cache');
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -118,7 +120,9 @@ try {
         return text;
     }
     function fetchUpdates() {
-        fetch('nova-events.php?after=' + latestId)
+        fetch('nova-events.php?after=' + latestId + '&_=' + Date.now(), {
+            cache: 'no-store'
+        })
             .then(r => r.json())
             .then(rows => {
                 rows.forEach(row => {

--- a/nova-events.php
+++ b/nova-events.php
@@ -2,6 +2,8 @@
 require_once 'db_config.php';
 
 header('Content-Type: application/json');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+header('Pragma: no-cache');
 
 $after = isset($_GET['after']) ? intval($_GET['after']) : 0;
 


### PR DESCRIPTION
## Summary
- disable caching headers on nova-data and nova-events PHP handlers
- add `no-store` fetch option and timestamp param for nova-events fetch

## Testing
- `php -l nova-data.php`
- `php -l nova-events.php`

------
https://chatgpt.com/codex/tasks/task_e_68715f1621908330bf7ef5513bfcbd6a